### PR TITLE
Distinguish between multiple commits and multiple versions

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -24,13 +24,15 @@ npm install -g backport
 
 ### Options
 
-| Option        | Description                         | Accepts                    |
-| ------------- | ----------------------------------- | -------------------------- |
-| --multiple    | Select multiple versions or commits | boolean (defaults to true) |
-| --own         | Only show own commits               | boolean (defaults to true) |
-| --config      | Show configuration file             |                            |
-| --help        | Show help                           |                            |
-| -v, --version | Show version number                 |                            |
+| Option              | Description                               | Accepts                    |
+| ------------------- | ----------------------------------------- | -------------------------- |
+| --multiple          | Backport multiple commits and/or versions | boolean (defaults to true) |
+| --multiple-commits  | Backport multiple commits                 | boolean (defaults to true) |
+| --multiple-versions | Backport to multiple versions             | boolean (defaults to true) |
+| --own               | Only show own commits                     | boolean (defaults to true) |
+| --config            | Show configuration file                   |                            |
+| --help              | Show help                                 |                            |
+| -v, --version       | Show version number                       |                            |
 
 ### Configuration
 

--- a/readme.MD
+++ b/readme.MD
@@ -63,11 +63,17 @@ your Github username and a Github Access Token (can be created
   "repositories": [
     {
       "name": "elastic/elasticsearch",
-      "versions": ["6.x", "6.0", "5.6", "5.5", "5.4"]
+      "versions": ["6.x", "6.1", "6.0"]
     },
     {
       "name": "elastic/kibana",
-      "versions": ["6.x", "6.0", "5.6", "5.5", "5.4"],
+
+      // You can pre-select versions you use often
+      "versions": [
+        { "name": "6.x", "checked": true },
+        { "name": "6.1", "checked": true },
+        "6.0"
+      ]
       "labels": ["backport"]
     }
   ]

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -9,8 +9,18 @@ const isBool = value => typeof value === 'boolean';
 const args = yargs
   .usage('$0 [args]')
   .option('multiple', {
-    default: isBool(config.multiple) ? config.multiple : true,
+    default: undefined,
     description: 'Select multiple versions and/or commits',
+    type: 'boolean'
+  })
+  .option('multiple-commits', {
+    default: isBool(config.multipleCommits) ? config.multipleCommits : false,
+    description: 'Backport multiple commits',
+    type: 'boolean'
+  })
+  .option('multiple-versions', {
+    default: isBool(config.multipleVersions) ? config.multipleVersions : true,
+    description: 'Backport to multiple version',
     type: 'boolean'
   })
   .option('own', {
@@ -31,6 +41,18 @@ if (args.config) {
   return;
 }
 
-const options = Object.assign({}, args, { cwd: process.cwd() });
+const options = Object.assign(
+  {},
+  args,
+  {
+    multipleVersions: isBool(args.multiple)
+      ? args.multiple
+      : args.multipleVersions,
+    multipleCommits: isBool(args.multiple)
+      ? args.multiple
+      : args.multipleCommits
+  },
+  { cwd: process.cwd() }
+);
 
 initSteps(config, options);

--- a/src/cli/steps.js
+++ b/src/cli/steps.js
@@ -30,11 +30,11 @@ function initSteps(config, options) {
         owner,
         repoName,
         options.own ? config.username : null,
-        options.multiple
+        options.multipleCommits
       )
     )
     .then(c => (commits = c))
-    .then(() => promptVersions(repoConfig.versions, options.multiple))
+    .then(() => promptVersions(repoConfig.versions, options.multipleVersions))
     .then(v => (versions = v))
     .then(() => maybeSetupRepo(owner, repoName, config.username))
     .then(() =>

--- a/src/cli/test/__snapshots__/steps.test.js.snap
+++ b/src/cli/test/__snapshots__/steps.test.js.snap
@@ -128,8 +128,11 @@ Array [
   // Only allow picking own commits to backport
   \\"own\\": true,
 
-  // Allow picking multiple versions and/or commits
-  \\"multiple\\": true,
+  // Backport multiple commits
+  \\"multipleCommits\\": false,
+
+  // Backport to multiple versions
+  \\"multipleVersions\\": true,
 
   // Repositories and the versions that will be available in backport cli
   \\"repositories\\": [

--- a/src/lib/configTemplate.json
+++ b/src/lib/configTemplate.json
@@ -9,8 +9,11 @@
   // Only allow picking own commits to backport
   "own": true,
 
-  // Allow picking multiple versions and/or commits
-  "multiple": true,
+  // Backport multiple commits
+  "multipleCommits": false,
+
+  // Backport to multiple versions
+  "multipleVersions": true,
 
   // Repositories and the versions that will be available in backport cli
   "repositories": [


### PR DESCRIPTION
Currently it is possible to specify `multiple` in the config. `true` will give the user a checkbox (instead of a single select list), and the user can choose multiple commits to backport, and multiple versions to backport to. 

The issue is, that most of the time the user might just select a single commit but multiple versions to backport to. In those cases, it is much easier to have a "select list" instead of checkboxes when picking the commit, while still having the checkboxes for versions.