### PR TITLE
fix: make engines match nvmrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     ]
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
     "axios": "^0.18.0",


### PR DESCRIPTION
The node version in the engines section of the package.json file was out of sync with the nvmrc file. As a result, installing this in node 6 wasn't an issue, but the postinstall script fails.

This will make npm/yarn show a warning when installing in node 6.