### PR TITLE
Fix broken shebang on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint ./src",
     "prepush": "npm run lint",
     "precommit": "lint-staged",
-    "postinstall": "scripts/postinstall.js"
+    "postinstall": "node scripts/postinstall.js"
   },
   "lint-staged": {
     "*.js": ["prettier --write", "git add"]

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 const { getGlobalConfigPath } = require('../src/lib/env');
 const { maybeCreateGlobalConfigAndFolder } = require('../src/lib/configs');
 


### PR DESCRIPTION
Windows doesn't like shebangs in the beginning of JS files. Instead just directly execute via `node` using the `package.json`.