### PR TITLE
Explicitly set remote branch name when doing git push

### DIFF
--- a/src/lib/git.js
+++ b/src/lib/git.js
@@ -91,7 +91,7 @@ function createAndCheckoutBranch(owner, repoName, baseBranch, featureBranch) {
 }
 
 function push(owner, repoName, username, branchName) {
-  return rpc.exec(`git push ${username} ${branchName} --force`, {
+  return rpc.exec(`git push ${username} ${branchName}:${branchName} --force`, {
     cwd: env.getRepoPath(owner, repoName)
   });
 }

--- a/test/__snapshots__/cliService.test.js.snap
+++ b/test/__snapshots__/cliService.test.js.snap
@@ -62,7 +62,7 @@ Array [
     [Function],
   ],
   Array [
-    "git push sqren backport/6.x/pr-myPullRequest_pr-myOtherPullRequest --force",
+    "git push sqren backport/6.x/pr-myPullRequest_pr-myOtherPullRequest:backport/6.x/pr-myPullRequest_pr-myOtherPullRequest --force",
     Object {
       "cwd": "/myHomeDir/.backport/repositories/elastic/kibana",
       "maxBuffer": 104857600,
@@ -134,7 +134,7 @@ Array [
     [Function],
   ],
   Array [
-    "git push sqren backport/6.x/pr-myPullRequest_pr-myOtherPullRequest --force",
+    "git push sqren backport/6.x/pr-myPullRequest_pr-myOtherPullRequest:backport/6.x/pr-myPullRequest_pr-myOtherPullRequest --force",
     Object {
       "cwd": "/myHomeDir/.backport/repositories/elastic/kibana",
       "maxBuffer": 104857600,
@@ -166,7 +166,7 @@ Array [
     [Function],
   ],
   Array [
-    "git push sqren backport/6.x/commit-mySha --force",
+    "git push sqren backport/6.x/commit-mySha:backport/6.x/commit-mySha --force",
     Object {
       "cwd": "/myHomeDir/.backport/repositories/elastic/kibana",
       "maxBuffer": 104857600,

--- a/test/__snapshots__/steps.test.js.snap
+++ b/test/__snapshots__/steps.test.js.snap
@@ -50,7 +50,7 @@ Array [
     [Function],
   ],
   Array [
-    "git push sqren backport/6.2/pr-myPullRequest --force",
+    "git push sqren backport/6.2/pr-myPullRequest:backport/6.2/pr-myPullRequest --force",
     Object {
       "cwd": "/myHomeDir/.backport/repositories/elastic/kibana",
       "maxBuffer": 104857600,
@@ -105,7 +105,7 @@ Array [
     [Function],
   ],
   Array [
-    "git push sqren backport/6.2/pr-myPullRequest --force",
+    "git push sqren backport/6.2/pr-myPullRequest:backport/6.2/pr-myPullRequest --force",
     Object {
       "cwd": "/myHomeDir/.backport/repositories/elastic/kibana",
       "maxBuffer": 104857600,
@@ -160,7 +160,7 @@ Array [
     [Function],
   ],
   Array [
-    "git push sqren backport/6.2/pr-myPullRequest --force",
+    "git push sqren backport/6.2/pr-myPullRequest:backport/6.2/pr-myPullRequest --force",
     Object {
       "cwd": "/myHomeDir/.backport/repositories/elastic/kibana",
       "maxBuffer": 104857600,
@@ -215,7 +215,7 @@ Array [
     [Function],
   ],
   Array [
-    "git push sqren backport/6.2/pr-myPullRequest --force",
+    "git push sqren backport/6.2/pr-myPullRequest:backport/6.2/pr-myPullRequest --force",
     Object {
       "cwd": "/myHomeDir/.backport/repositories/elastic/kibana",
       "maxBuffer": 104857600,


### PR DESCRIPTION
Before this change, my local git (version 2.14.1) was setting `6.x` as the remote branch for a local `backport/6.x/pr-20572`. This will ensure the right name is used.

Thanks @sqren for helping me to debug this issue!