### PR TITLE
Shorten names to work-around Windows path length problem

### DIFF
--- a/src/services/env.ts
+++ b/src/services/env.ts
@@ -3,20 +3,20 @@ import os from 'os';
 
 export function getGlobalConfigPath() {
   const homedir = os.homedir();
-  return path.join(homedir, '.backport', 'config.json');
+  return path.join(homedir, '.bp', 'config.json');
 }
 
 export function getReposPath() {
   const homedir = os.homedir();
-  return path.join(homedir, '.backport', 'repositories');
+  return path.join(homedir, '.bp', 'repo');
 }
 
 export function getRepoOwnerPath(owner: string) {
   const homedir = os.homedir();
-  return path.join(homedir, '.backport', 'repositories', owner);
+  return path.join(homedir, '.bp', 'repo', owner);
 }
 
 export function getRepoPath(owner: string, repoName: string) {
   const homedir = os.homedir();
-  return path.join(homedir, '.backport', 'repositories', owner, repoName);
+  return path.join(homedir, '.bp', 'repo', owner, repoName);
 }


### PR DESCRIPTION
I'm on Windows 10.  I do have all the `enable long paths` settings set, but some npm or node module still causes the backport tool to fail on current kibana master.

```
(node:164896) UnhandledPromiseRejectionWarning: Error: Command failed: git reset --hard && git clean -d --force && git checkout master && git pull origin master
Checking out files: 100% (4808/4808), done.
Already on 'master'
From github.com:elastic/kibana
 * branch                  master     -> FETCH_HEAD
   a683791da0..9133779bf0  master     -> origin/master
error: unable to create file src/legacy/core_plugins/kibana/public/management/sections/index_patterns/create_index_pattern_wizard/components/step_index_pattern/components/loading_indices/__jest__/__sna
pshots__/loading_indices.test.js.snap: Filename too long
error: unable to create file src/legacy/core_plugins/kibana/public/management/sections/index_patterns/create_index_pattern_wizard/components/step_index_pattern/components/status_message/__jest__/__snap
shots__/status_message.test.js.snap: Filename too long
error: unable to create file src/legacy/core_plugins/kibana/public/management/sections/index_patterns/create_index_pattern_wizard/components/step_time_field/components/advanced_options/__jest__/__snaps
hots__/advanced_options.test.js.snap: Filename too long
Checking out files: 100% (19148/19148), done.

    at ChildProcess.exithandler (child_process.js:294:12)
    at ChildProcess.emit (events.js:189:13)
    at maybeClose (internal/child_process.js:970:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)
(node:164896) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which
was not handled with .catch(). (rejection id: 2)
(node:164896) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

I hacked the `.backport` to `.bp` and `repositories` to `repo` in my local copy in node_modules and that was enough to allow the backport to work successfully (for now).

If there's some better way, I'm all for it.  But this did work for me.

FYI, my kibana root dir is;
`/c/Users/LeeDr/git/kibana`

but the backports are done in the slightly longer path;
`/c/Users/LeeDr/.backport/repositories/elastic/kibana`

which pushes the total length of some of these files to a length of 263;
`/c/Users/LeeDr/.backport/repositories/elastic/kibana/src/legacy/core_plugins/kibana/public/management/sections/index_patterns/create_index_pattern_wizard/components/step_index_pattern/components/loading_indices/__jest__/__snapshots__/loading_indices.test.js.snap`