### PR TITLE
Preserve `BackportOptions` object and simplify tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,37 @@
-**Run**
+# Contributing
+
+### Run
 
 ```
-# Compile and run
-npx ts-node ./src/index.ts --branch 6.1 --upstream sqren/backport-demo --all
+yarn start --branch 6.1 --upstream sqren/backport-demo --all
 ```
 
 or
 
 ```
 # Compile
-yarn build
+yarn tsc
 
 # Run
 node dist/index.js --branch 6.1 --upstream sqren/backport-demo --all
 ```
 
-**Test**
+### Debug
+
+**Run tests**
 
 ```
 yarn test
+```
+
+**Run tests continously**
+
+```
+yarn test --watch
+```
+
+**Compile typescript continously**
+
+```
+yarn tsc --watch
 ```

--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
     "cover": "jest --coverage",
     "format": "prettier \"./src/**/*.ts\" --write",
     "lint": "tsc -p ./test/tsconfig.json && eslint ./src/**/*.ts",
     "postinstall": "test -f ./dist/scripts/runPostinstall.js && node ./dist/scripts/runPostinstall.js || echo 'Dist folder missing'",
     "prepublishOnly": "tsc",
     "publish-dry-run": "tar -tf $(npm pack)",
-    "test": "jest"
+    "test": "jest",
+    "start": "ts-node --transpile-only ./src/index.ts"
   },
   "lint-staged": {
     "*.ts": [
@@ -127,6 +127,6 @@
     "prettier": "^1.17.0",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.1.0",
-    "typescript": "^3.4.4"
+    "typescript": "^3.4.5"
   }
 }

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -5,7 +5,7 @@ import { getOptionsFromConfigFiles } from './config/config';
 import { PromiseReturnType } from '../types/commons';
 import { getGlobalConfigPath } from '../services/env';
 
-export type BackportOptions = PromiseReturnType<typeof getOptions>;
+export type BackportOptions = Readonly<PromiseReturnType<typeof getOptions>>;
 export async function getOptions(argv: typeof process.argv) {
   const optionsFromConfig = await getOptionsFromConfigFiles();
   const optionsFromCli = getOptionsFromCliArgs(optionsFromConfig, argv);
@@ -66,7 +66,8 @@ export function validateOptions({
     );
   }
 
-  if (!upstream) {
+  const [repoOwner, repoName] = (upstream || '').split('/');
+  if (!repoOwner || !repoName) {
     throw new HandledError(
       getErrorMessage({ field: 'upstream', exampleValue: 'elastic/kibana' })
     );
@@ -79,6 +80,8 @@ export function validateOptions({
   }
 
   return {
+    repoOwner,
+    repoName,
     accessToken,
     all,
     apiHostname,
@@ -92,7 +95,6 @@ export function validateOptions({
     prTitle,
     prDescription,
     sha,
-    upstream,
     username
   };
 }

--- a/src/services/env.ts
+++ b/src/services/env.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import os from 'os';
+import { BackportOptions } from '../options/options';
 
 export function getGlobalConfigPath() {
   const homedir = os.homedir();
@@ -11,12 +12,12 @@ export function getReposPath() {
   return path.join(homedir, '.backport', 'repositories');
 }
 
-export function getRepoOwnerPath(owner: string) {
+export function getRepoOwnerPath({ repoOwner }: BackportOptions) {
   const homedir = os.homedir();
-  return path.join(homedir, '.backport', 'repositories', owner);
+  return path.join(homedir, '.backport', 'repositories', repoOwner);
 }
 
-export function getRepoPath(owner: string, repoName: string) {
+export function getRepoPath({ repoOwner, repoName }: BackportOptions) {
   const homedir = os.homedir();
-  return path.join(homedir, '.backport', 'repositories', owner, repoName);
+  return path.join(homedir, '.backport', 'repositories', repoOwner, repoName);
 }

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -23,7 +23,6 @@ export function getShortSha(sha: string) {
   return sha.slice(0, 7);
 }
 
-let accessToken: string;
 function getCommitMessage(message: string) {
   return message.split('\n')[0].trim();
 }
@@ -31,12 +30,20 @@ function getCommitMessage(message: string) {
 export async function fetchCommitsByAuthor(
   options: BackportOptions
 ): Promise<Commit[]> {
+  const {
+    accessToken,
+    all,
+    apiHostname,
+    repoName,
+    repoOwner,
+    username
+  } = options;
+
   const query: GithubQuery = {
     access_token: accessToken,
     per_page: 10
   };
 
-  const { all, apiHostname, repoName, repoOwner, username } = options;
   if (!all) {
     query.author = username;
     query.per_page = 5;
@@ -65,7 +72,7 @@ export async function fetchCommitsByAuthor(
 export async function fetchCommitBySha(
   options: BackportOptions & { sha: string }
 ): Promise<Commit> {
-  const { apiHostname, repoName, repoOwner, sha } = options;
+  const { apiHostname, repoName, repoOwner, sha, accessToken } = options;
   try {
     const res: AxiosResponse<GithubSearch<GithubCommit>> = await axios(
       `https://${apiHostname}/search/commits?q=hash:${sha}%20repo:${repoOwner}/${repoName}&per_page=1&access_token=${accessToken}`,
@@ -95,7 +102,7 @@ export async function fetchCommitBySha(
 }
 
 async function fetchPullRequestNumberBySha(
-  { apiHostname, repoName, repoOwner }: BackportOptions,
+  { apiHostname, repoName, repoOwner, accessToken }: BackportOptions,
   commitSha: string
 ): Promise<number> {
   try {
@@ -109,7 +116,7 @@ async function fetchPullRequestNumberBySha(
 }
 
 export async function createPullRequest(
-  { apiHostname, repoName, repoOwner }: BackportOptions,
+  { apiHostname, repoName, repoOwner, accessToken }: BackportOptions,
   payload: ReturnType<typeof getPullRequestPayload>
 ) {
   try {
@@ -127,7 +134,7 @@ export async function createPullRequest(
 }
 
 export async function addLabelsToPullRequest(
-  { apiHostname, repoName, repoOwner, labels }: BackportOptions,
+  { apiHostname, repoName, repoOwner, labels, accessToken }: BackportOptions,
   pullNumber: number
 ) {
   try {
@@ -179,10 +186,6 @@ export async function verifyAccessToken({
         throw e.message;
     }
   }
-}
-
-export function setAccessToken(token: string) {
-  accessToken = token;
 }
 
 function getError(e: GithubApiError) {

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -10,6 +10,7 @@ import querystring from 'querystring';
 import get from 'lodash.get';
 import isEmpty from 'lodash.isempty';
 import { HandledError } from './HandledError';
+import { BackportOptions } from '../options/options';
 import { getPullRequestPayload } from '../steps/doBackportVersions';
 
 export interface Commit {
@@ -28,40 +29,31 @@ function getCommitMessage(message: string) {
 }
 
 export async function fetchCommitsByAuthor(
-  owner: string,
-  repoName: string,
-  author: string | null,
-  apiHostname: string
+  options: BackportOptions
 ): Promise<Commit[]> {
   const query: GithubQuery = {
     access_token: accessToken,
     per_page: 10
   };
 
-  if (author) {
-    query.author = author;
+  const { all, apiHostname, repoName, repoOwner, username } = options;
+  if (!all) {
+    query.author = username;
     query.per_page = 5;
   }
 
   try {
     const res: AxiosResponse<GithubCommit[]> = await axios(
-      `https://${apiHostname}/repos/${owner}/${repoName}/commits?${querystring.stringify(
+      `https://${apiHostname}/repos/${repoOwner}/${repoName}/commits?${querystring.stringify(
         query
       )}`
     );
 
     const promises = res.data.map(async commit => {
       const sha = commit.sha;
-      return {
-        message: getCommitMessage(commit.commit.message),
-        sha,
-        pullNumber: await fetchPullRequestNumberBySha(
-          owner,
-          repoName,
-          sha,
-          apiHostname
-        )
-      };
+      const pullNumber = await fetchPullRequestNumberBySha(options, sha);
+      const message = getCommitMessage(commit.commit.message);
+      return { message, sha, pullNumber };
     });
 
     return Promise.all(promises);
@@ -71,14 +63,12 @@ export async function fetchCommitsByAuthor(
 }
 
 export async function fetchCommitBySha(
-  owner: string,
-  repoName: string,
-  sha: string,
-  apiHostname: string
+  options: BackportOptions & { sha: string }
 ): Promise<Commit> {
+  const { apiHostname, repoName, repoOwner, sha } = options;
   try {
     const res: AxiosResponse<GithubSearch<GithubCommit>> = await axios(
-      `https://${apiHostname}/search/commits?q=hash:${sha}%20repo:${owner}/${repoName}&per_page=1&access_token=${accessToken}`,
+      `https://${apiHostname}/search/commits?q=hash:${sha}%20repo:${repoOwner}/${repoName}&per_page=1&access_token=${accessToken}`,
       {
         headers: {
           Accept: 'application/vnd.github.cloak-preview'
@@ -92,12 +82,7 @@ export async function fetchCommitBySha(
 
     const commitRes = res.data.items[0];
     const fullSha = commitRes.sha;
-    const pullNumber = await fetchPullRequestNumberBySha(
-      owner,
-      repoName,
-      fullSha,
-      apiHostname
-    );
+    const pullNumber = await fetchPullRequestNumberBySha(options, fullSha);
 
     return {
       message: getCommitMessage(commitRes.commit.message),
@@ -110,14 +95,12 @@ export async function fetchCommitBySha(
 }
 
 async function fetchPullRequestNumberBySha(
-  owner: string,
-  repoName: string,
-  commitSha: string,
-  apiHostname: string
+  { apiHostname, repoName, repoOwner }: BackportOptions,
+  commitSha: string
 ): Promise<number> {
   try {
     const res: AxiosResponse<GithubSearch<GithubIssue>> = await axios(
-      `https://${apiHostname}/search/issues?q=repo:${owner}/${repoName}+${commitSha}+base:master&access_token=${accessToken}`
+      `https://${apiHostname}/search/issues?q=repo:${repoOwner}/${repoName}+${commitSha}+base:master&access_token=${accessToken}`
     );
     return get(res.data.items[0], 'number');
   } catch (e) {
@@ -126,14 +109,12 @@ async function fetchPullRequestNumberBySha(
 }
 
 export async function createPullRequest(
-  owner: string,
-  repoName: string,
-  payload: ReturnType<typeof getPullRequestPayload>,
-  apiHostname: string
+  { apiHostname, repoName, repoOwner }: BackportOptions,
+  payload: ReturnType<typeof getPullRequestPayload>
 ) {
   try {
     const res: AxiosResponse<GithubIssue> = await axios.post(
-      `https://${apiHostname}/repos/${owner}/${repoName}/pulls?access_token=${accessToken}`,
+      `https://${apiHostname}/repos/${repoOwner}/${repoName}/pulls?access_token=${accessToken}`,
       payload
     );
     return {
@@ -146,15 +127,12 @@ export async function createPullRequest(
 }
 
 export async function addLabelsToPullRequest(
-  owner: string,
-  repoName: string,
-  pullNumber: number,
-  labels: string[],
-  apiHostname: string
+  { apiHostname, repoName, repoOwner, labels }: BackportOptions,
+  pullNumber: number
 ) {
   try {
     return await axios.post(
-      `https://${apiHostname}/repos/${owner}/${repoName}/issues/${pullNumber}/labels?access_token=${accessToken}`,
+      `https://${apiHostname}/repos/${repoOwner}/${repoName}/issues/${pullNumber}/labels?access_token=${accessToken}`,
       labels
     );
   } catch (e) {
@@ -162,15 +140,15 @@ export async function addLabelsToPullRequest(
   }
 }
 
-export async function verifyAccessToken(
-  owner: string,
-  repoName: string,
-  accessToken: string,
-  apiHostname: string
-) {
+export async function verifyAccessToken({
+  accessToken,
+  apiHostname,
+  repoName,
+  repoOwner
+}: BackportOptions) {
   try {
     return await axios.head(
-      `https://${apiHostname}/repos/${owner}/${repoName}?access_token=${accessToken}`
+      `https://${apiHostname}/repos/${repoOwner}/${repoName}?access_token=${accessToken}`
     );
   } catch (e) {
     const error = e as GithubApiError;
@@ -190,12 +168,12 @@ export async function verifyAccessToken(
       case 404:
         if (grantedScopes === requiredScopes) {
           throw new HandledError(
-            `The repository "${owner}/${repoName}" doesn't exist`
+            `The repository "${repoOwner}/${repoName}" doesn't exist`
           );
         }
 
         throw new HandledError(
-          `You do not have access to the repository "${owner}/${repoName}". Please make sure your access token has the required scopes.\n\nRequired scopes: ${requiredScopes}\nAccess token scopes: ${grantedScopes}`
+          `You do not have access to the repository "${repoOwner}/${repoName}". Please make sure your access token has the required scopes.\n\nRequired scopes: ${requiredScopes}\nAccess token scopes: ${grantedScopes}`
         );
       default:
         throw e.message;

--- a/src/steps/getCommits.ts
+++ b/src/steps/getCommits.ts
@@ -9,33 +9,20 @@ import isEmpty from 'lodash.isempty';
 import ora = require('ora');
 
 export async function getCommits(options: BackportOptions) {
-  const [owner, repoName] = options.upstream.split('/');
-
-  if (options.sha) {
-    return [
-      await getCommitBySha(owner, repoName, options.sha, options.apiHostname)
-    ];
+  const { sha } = options; // must extract sha to satisfy the ts gods
+  if (sha) {
+    return [await getCommitBySha({ ...options, sha })];
   }
 
-  const author = options.all ? null : options.username;
-  return await getCommitsByPrompt(
-    owner,
-    repoName,
-    author,
-    options.multipleCommits,
-    options.apiHostname
-  );
+  return await getCommitsByPrompt(options);
 }
 
 export async function getCommitBySha(
-  owner: string,
-  repoName: string,
-  sha: string,
-  apiHostname: string
+  options: BackportOptions & { sha: string }
 ) {
-  const spinner = ora(`Loading commit "${getShortSha(sha)}"`).start();
+  const spinner = ora(`Loading commit "${getShortSha(options.sha)}"`).start();
   try {
-    const commit = await fetchCommitBySha(owner, repoName, sha, apiHostname);
+    const commit = await fetchCommitBySha(options);
     spinner.stop();
     return commit;
   } catch (e) {
@@ -44,31 +31,20 @@ export async function getCommitBySha(
   }
 }
 
-async function getCommitsByPrompt(
-  owner: string,
-  repoName: string,
-  author: string | null,
-  multipleCommits: boolean,
-  apiHostname: string
-) {
+async function getCommitsByPrompt(options: BackportOptions) {
   const spinner = ora('Loading commits...').start();
   try {
-    const commits = await fetchCommitsByAuthor(
-      owner,
-      repoName,
-      author,
-      apiHostname
-    );
+    const commits = await fetchCommitsByAuthor(options);
     if (isEmpty(commits)) {
-      const warningText = author
-        ? 'There are no commits by you in this repository'
-        : 'There are no commits in this repository';
+      const warningText = options.all
+        ? 'There are no commits in this repository'
+        : 'There are no commits by you in this repository';
 
       spinner.fail(warningText);
       process.exit(1);
     }
     spinner.stop();
-    return promptForCommits(commits, multipleCommits);
+    return promptForCommits(commits, options.multipleCommits);
   } catch (e) {
     spinner.fail();
     throw e;

--- a/src/steps/steps.ts
+++ b/src/steps/steps.ts
@@ -1,4 +1,4 @@
-import { setAccessToken, verifyAccessToken } from '../services/github';
+import { verifyAccessToken } from '../services/github';
 import { doBackportVersions } from './doBackportVersions';
 import { BackportOptions } from '../options/options';
 import { getCommits } from './getCommits';
@@ -7,7 +7,6 @@ import { maybeSetupRepo } from './maybeSetupRepo';
 
 export async function initSteps(options: BackportOptions) {
   await verifyAccessToken(options);
-  setAccessToken(options.accessToken);
 
   const commits = await getCommits(options);
   const branches = await getBranches(options);

--- a/src/steps/steps.ts
+++ b/src/steps/steps.ts
@@ -6,34 +6,12 @@ import { getBranches } from './getBranches';
 import { maybeSetupRepo } from './maybeSetupRepo';
 
 export async function initSteps(options: BackportOptions) {
-  const [owner, repoName] = options.upstream.split('/');
-  await verifyAccessToken(
-    owner,
-    repoName,
-    options.accessToken,
-    options.apiHostname
-  );
+  await verifyAccessToken(options);
   setAccessToken(options.accessToken);
 
   const commits = await getCommits(options);
   const branches = await getBranches(options);
 
-  await maybeSetupRepo({
-    owner,
-    repoName,
-    username: options.username,
-    accessToken: options.accessToken,
-    gitHostname: options.gitHostname
-  });
-  await doBackportVersions(
-    owner,
-    repoName,
-    commits,
-    branches,
-    options.username,
-    options.labels,
-    options.prTitle,
-    options.prDescription,
-    options.apiHostname
-  );
+  await maybeSetupRepo(options);
+  await doBackportVersions(options, commits, branches);
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "@typescript-eslint/no-object-literal-type-assertion": "off",
+    "@typescript-eslint/no-explicit-any": "off"
+  }
+}

--- a/test/services/env.test.ts
+++ b/test/services/env.test.ts
@@ -4,6 +4,7 @@ import {
   getRepoOwnerPath,
   getRepoPath
 } from '../../src/services/env';
+import { BackportOptions } from '../../src/options/options';
 
 describe('env.js', () => {
   test('getGlobalConfigPath', () => {
@@ -15,14 +16,17 @@ describe('env.js', () => {
   });
 
   test('getRepoOwnerPath', () => {
-    expect(getRepoOwnerPath('elastic')).toBe(
+    expect(getRepoOwnerPath({ repoOwner: 'elastic' } as BackportOptions)).toBe(
       '/myHomeDir/.backport/repositories/elastic'
     );
   });
 
   test('getRepoPath', () => {
-    expect(getRepoPath('elastic', 'kibana')).toBe(
-      '/myHomeDir/.backport/repositories/elastic/kibana'
-    );
+    expect(
+      getRepoPath({
+        repoOwner: 'elastic',
+        repoName: 'kibana'
+      } as BackportOptions)
+    ).toBe('/myHomeDir/.backport/repositories/elastic/kibana');
   });
 });

--- a/test/services/git.test.ts
+++ b/test/services/git.test.ts
@@ -1,16 +1,19 @@
 import { addRemote } from '../../src/services/git';
 import * as rpc from '../../src/services/rpc';
+import { BackportOptions } from '../../src/options/options';
 
 describe('addRemote', () => {
   it('add correct origin remote', async () => {
     const spy = jest.spyOn(rpc, 'exec').mockResolvedValue({} as any);
-    await addRemote({
-      accessToken: 'myAccessToken',
-      owner: 'elastic',
-      repoName: 'kibana',
-      username: 'elastic',
-      gitHostname: 'github.com'
-    });
+    await addRemote(
+      {
+        accessToken: 'myAccessToken',
+        repoOwner: 'elastic',
+        repoName: 'kibana',
+        gitHostname: 'github.com'
+      } as BackportOptions,
+      'elastic'
+    );
 
     return expect(spy).toHaveBeenCalledWith(
       'git remote add elastic https://myAccessToken@github.com/elastic/kibana.git',
@@ -20,13 +23,15 @@ describe('addRemote', () => {
 
   it('add correct user remote', async () => {
     const spy = jest.spyOn(rpc, 'exec').mockResolvedValue({} as any);
-    await addRemote({
-      accessToken: 'myAccessToken',
-      owner: 'elastic',
-      repoName: 'kibana',
-      username: 'sqren',
-      gitHostname: 'github.com'
-    });
+    await addRemote(
+      {
+        accessToken: 'myAccessToken',
+        repoOwner: 'elastic',
+        repoName: 'kibana',
+        gitHostname: 'github.com'
+      } as BackportOptions,
+      'sqren'
+    );
 
     return expect(spy).toHaveBeenCalledWith(
       'git remote add sqren https://myAccessToken@github.com/sqren/kibana.git',
@@ -36,13 +41,15 @@ describe('addRemote', () => {
 
   it('allows custom github url', async () => {
     const spy = jest.spyOn(rpc, 'exec').mockResolvedValue({} as any);
-    await addRemote({
-      accessToken: 'myAccessToken',
-      owner: 'elastic',
-      repoName: 'kibana',
-      username: 'sqren',
-      gitHostname: 'github.my-company.com'
-    });
+    await addRemote(
+      {
+        accessToken: 'myAccessToken',
+        repoOwner: 'elastic',
+        repoName: 'kibana',
+        gitHostname: 'github.my-company.com'
+      } as BackportOptions,
+      'sqren'
+    );
 
     return expect(spy).toHaveBeenCalledWith(
       'git remote add sqren https://myAccessToken@github.my-company.com/sqren/kibana.git',

--- a/test/services/github.test.ts
+++ b/test/services/github.test.ts
@@ -4,21 +4,22 @@ import {
 } from '../../src/services/github';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import { BackportOptions } from '../../src/options/options';
 
 describe('getCommits', () => {
   it('should return commits with pull request', async () => {
     const mock = new MockAdapter(axios);
-    const owner = 'elastic';
+    const repoOwner = 'elastic';
     const repoName = 'kibana';
     const accessToken = 'myAccessToken';
-    const author = 'sqren';
+    const username = 'sqren';
     const commitSha = 'myCommitSha';
     const apiHostname = 'api.github.com';
     setAccessToken(accessToken);
 
     mock
       .onGet(
-        `https://api.github.com/repos/${owner}/${repoName}/commits?access_token=${accessToken}&per_page=5&author=${author}`
+        `https://api.github.com/repos/${repoOwner}/${repoName}/commits?access_token=${accessToken}&per_page=5&author=${username}`
       )
       .reply(200, [
         {
@@ -31,7 +32,7 @@ describe('getCommits', () => {
 
     mock
       .onGet(
-        `https://api.github.com/search/issues?q=repo:${owner}/${repoName}+${commitSha}+base:master&access_token=${accessToken}`
+        `https://api.github.com/search/issues?q=repo:${repoOwner}/${repoName}+${commitSha}+base:master&access_token=${accessToken}`
       )
       .reply(200, {
         items: [
@@ -42,7 +43,12 @@ describe('getCommits', () => {
       });
 
     expect(
-      await fetchCommitsByAuthor(owner, repoName, author, apiHostname)
+      await fetchCommitsByAuthor({
+        repoOwner,
+        repoName,
+        username,
+        apiHostname
+      } as BackportOptions)
     ).toEqual([
       {
         message: 'myMessage',
@@ -54,17 +60,17 @@ describe('getCommits', () => {
 
   it('should return commits without pull request', async () => {
     const mock = new MockAdapter(axios);
-    const owner = 'elastic';
+    const repoOwner = 'elastic';
     const repoName = 'kibana';
     const accessToken = 'myAccessToken';
-    const author = 'sqren';
+    const username = 'sqren';
     const commitSha = 'myCommitSha';
     const apiHostname = 'api.github.com';
     setAccessToken(accessToken);
 
     mock
       .onGet(
-        `https://api.github.com/repos/${owner}/${repoName}/commits?access_token=${accessToken}&per_page=5&author=${author}`
+        `https://api.github.com/repos/${repoOwner}/${repoName}/commits?access_token=${accessToken}&per_page=5&author=${username}`
       )
       .reply(200, [
         {
@@ -77,12 +83,17 @@ describe('getCommits', () => {
 
     mock
       .onGet(
-        `https://api.github.com/search/issues?q=repo:${owner}/${repoName}+${commitSha}+base:master&access_token=${accessToken}`
+        `https://api.github.com/search/issues?q=repo:${repoOwner}/${repoName}+${commitSha}+base:master&access_token=${accessToken}`
       )
       .reply(200, { items: [] });
 
     expect(
-      await fetchCommitsByAuthor(owner, repoName, author, apiHostname)
+      await fetchCommitsByAuthor({
+        repoOwner,
+        repoName,
+        username,
+        apiHostname
+      } as BackportOptions)
     ).toEqual([
       {
         message: 'myMessage',
@@ -94,17 +105,17 @@ describe('getCommits', () => {
 
   it('allows a custom github api hostname', async () => {
     const mock = new MockAdapter(axios);
-    const owner = 'elastic';
+    const repoOwner = 'elastic';
     const repoName = 'kibana';
     const accessToken = 'myAccessToken';
-    const author = 'sqren';
+    const username = 'sqren';
     const commitSha = 'myCommitSha';
     const apiHostname = 'api.github.my-company.com';
     setAccessToken(accessToken);
 
     mock
       .onGet(
-        `https://${apiHostname}/repos/${owner}/${repoName}/commits?access_token=${accessToken}&per_page=5&author=${author}`
+        `https://${apiHostname}/repos/${repoOwner}/${repoName}/commits?access_token=${accessToken}&per_page=5&author=${username}`
       )
       .reply(200, [
         {
@@ -117,7 +128,7 @@ describe('getCommits', () => {
 
     mock
       .onGet(
-        `https://${apiHostname}/search/issues?q=repo:${owner}/${repoName}+${commitSha}+base:master&access_token=${accessToken}`
+        `https://${apiHostname}/search/issues?q=repo:${repoOwner}/${repoName}+${commitSha}+base:master&access_token=${accessToken}`
       )
       .reply(200, {
         items: [
@@ -128,7 +139,12 @@ describe('getCommits', () => {
       });
 
     expect(
-      await fetchCommitsByAuthor(owner, repoName, author, apiHostname)
+      await fetchCommitsByAuthor({
+        repoOwner,
+        repoName,
+        apiHostname,
+        username
+      } as BackportOptions)
     ).toEqual([
       {
         message: 'myMessage',

--- a/test/services/github.test.ts
+++ b/test/services/github.test.ts
@@ -1,55 +1,42 @@
 import {
   fetchCommitsByAuthor,
-  setAccessToken
+  fetchCommitBySha
 } from '../../src/services/github';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { BackportOptions } from '../../src/options/options';
 
-describe('getCommits', () => {
+function getDefaultOptions(options: Partial<BackportOptions> = {}) {
+  return {
+    repoOwner: 'elastic',
+    repoName: 'kibana',
+    accessToken: 'myAccessToken',
+    username: 'sqren',
+    apiHostname: 'api.github.com',
+    ...options
+  } as BackportOptions;
+}
+
+describe('fetchCommitsByAuthor', () => {
   it('should return commits with pull request', async () => {
     const mock = new MockAdapter(axios);
-    const repoOwner = 'elastic';
-    const repoName = 'kibana';
-    const accessToken = 'myAccessToken';
-    const username = 'sqren';
     const commitSha = 'myCommitSha';
-    const apiHostname = 'api.github.com';
-    setAccessToken(accessToken);
+    const options = getDefaultOptions();
+    const { repoOwner, repoName, accessToken, username } = options;
 
     mock
       .onGet(
         `https://api.github.com/repos/${repoOwner}/${repoName}/commits?access_token=${accessToken}&per_page=5&author=${username}`
       )
-      .reply(200, [
-        {
-          commit: {
-            message: 'myMessage'
-          },
-          sha: commitSha
-        }
-      ]);
+      .reply(200, [{ commit: { message: 'myMessage' }, sha: commitSha }]);
 
     mock
       .onGet(
         `https://api.github.com/search/issues?q=repo:${repoOwner}/${repoName}+${commitSha}+base:master&access_token=${accessToken}`
       )
-      .reply(200, {
-        items: [
-          {
-            number: 'myPullRequestNumber'
-          }
-        ]
-      });
+      .reply(200, { items: [{ number: 'myPullRequestNumber' }] });
 
-    expect(
-      await fetchCommitsByAuthor({
-        repoOwner,
-        repoName,
-        username,
-        apiHostname
-      } as BackportOptions)
-    ).toEqual([
+    expect(await fetchCommitsByAuthor(options)).toEqual([
       {
         message: 'myMessage',
         pullNumber: 'myPullRequestNumber',
@@ -60,26 +47,15 @@ describe('getCommits', () => {
 
   it('should return commits without pull request', async () => {
     const mock = new MockAdapter(axios);
-    const repoOwner = 'elastic';
-    const repoName = 'kibana';
-    const accessToken = 'myAccessToken';
-    const username = 'sqren';
     const commitSha = 'myCommitSha';
-    const apiHostname = 'api.github.com';
-    setAccessToken(accessToken);
+    const options = getDefaultOptions();
+    const { repoOwner, repoName, accessToken, username } = options;
 
     mock
       .onGet(
         `https://api.github.com/repos/${repoOwner}/${repoName}/commits?access_token=${accessToken}&per_page=5&author=${username}`
       )
-      .reply(200, [
-        {
-          commit: {
-            message: 'myMessage'
-          },
-          sha: commitSha
-        }
-      ]);
+      .reply(200, [{ commit: { message: 'myMessage' }, sha: commitSha }]);
 
     mock
       .onGet(
@@ -87,14 +63,7 @@ describe('getCommits', () => {
       )
       .reply(200, { items: [] });
 
-    expect(
-      await fetchCommitsByAuthor({
-        repoOwner,
-        repoName,
-        username,
-        apiHostname
-      } as BackportOptions)
-    ).toEqual([
+    expect(await fetchCommitsByAuthor(options)).toEqual([
       {
         message: 'myMessage',
         pullNumber: undefined,
@@ -105,52 +74,59 @@ describe('getCommits', () => {
 
   it('allows a custom github api hostname', async () => {
     const mock = new MockAdapter(axios);
-    const repoOwner = 'elastic';
-    const repoName = 'kibana';
-    const accessToken = 'myAccessToken';
-    const username = 'sqren';
+    const options = getDefaultOptions({
+      apiHostname: 'api.github.my-company.com'
+    });
+    const { repoOwner, repoName, accessToken, username } = options;
     const commitSha = 'myCommitSha';
-    const apiHostname = 'api.github.my-company.com';
-    setAccessToken(accessToken);
 
     mock
       .onGet(
-        `https://${apiHostname}/repos/${repoOwner}/${repoName}/commits?access_token=${accessToken}&per_page=5&author=${username}`
+        `https://api.github.my-company.com/repos/${repoOwner}/${repoName}/commits?access_token=${accessToken}&per_page=5&author=${username}`
       )
-      .reply(200, [
-        {
-          commit: {
-            message: 'myMessage'
-          },
-          sha: commitSha
-        }
-      ]);
+      .reply(200, [{ commit: { message: 'myMessage' }, sha: commitSha }]);
 
     mock
       .onGet(
-        `https://${apiHostname}/search/issues?q=repo:${repoOwner}/${repoName}+${commitSha}+base:master&access_token=${accessToken}`
+        `https://api.github.my-company.com/search/issues?q=repo:${repoOwner}/${repoName}+${commitSha}+base:master&access_token=${accessToken}`
       )
-      .reply(200, {
-        items: [
-          {
-            number: 'myPullRequestNumber'
-          }
-        ]
-      });
+      .reply(200, { items: [{ number: 'myPullRequestNumber' }] });
 
-    expect(
-      await fetchCommitsByAuthor({
-        repoOwner,
-        repoName,
-        apiHostname,
-        username
-      } as BackportOptions)
-    ).toEqual([
+    expect(await fetchCommitsByAuthor(options)).toEqual([
       {
         message: 'myMessage',
         pullNumber: 'myPullRequestNumber',
         sha: 'myCommitSha'
       }
     ]);
+  });
+});
+
+describe('fetchCommitBySha', () => {
+  it('should return single commit with pull request', async () => {
+    const mock = new MockAdapter(axios);
+    const commitSha = 'myCommitSha';
+    const options = getDefaultOptions();
+    const { repoOwner, repoName, accessToken } = options;
+
+    mock
+      .onGet(
+        `https://api.github.com/search/commits?q=hash:${commitSha}%20repo:${repoOwner}/${repoName}&per_page=1&access_token=${accessToken}`
+      )
+      .reply(200, {
+        items: [{ commit: { message: 'myMessage' }, sha: commitSha }]
+      });
+
+    mock
+      .onGet(
+        `https://api.github.com/search/issues?q=repo:${repoOwner}/${repoName}+${commitSha}+base:master&access_token=${accessToken}`
+      )
+      .reply(200, { items: [{ number: 'myPullRequestNumber' }] });
+
+    expect(await fetchCommitBySha({ ...options, sha: commitSha })).toEqual({
+      message: 'myMessage',
+      pullNumber: 'myPullRequestNumber',
+      sha: 'myCommitSha'
+    });
   });
 });

--- a/test/steps/getCommits.test.ts
+++ b/test/steps/getCommits.test.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import nock from 'nock';
 import httpAdapter from 'axios/lib/adapters/http';
 import { getCommitBySha } from '../../src/steps/getCommits';
+import { BackportOptions } from '../../src/options/options';
 
 axios.defaults.adapter = httpAdapter;
 
@@ -22,12 +23,12 @@ describe('getCommitBySha', () => {
         items: []
       });
 
-    const commits = await getCommitBySha(
-      'elastic',
-      'kibana',
-      'myCommitSha',
-      'api.github.com'
-    );
+    const commits = await getCommitBySha({
+      repoOwner: 'elastic',
+      repoName: 'kibana',
+      sha: 'myCommitSha',
+      apiHostname: 'api.github.com'
+    } as BackportOptions & { sha: string });
     expect(commits).toEqual({
       message: '[Chrome] Bootstrap Angular into document.body (#15158)',
       sha: 'myCommitSha',
@@ -44,7 +45,12 @@ describe('getCommitBySha', () => {
       });
 
     await expect(
-      getCommitBySha('elastic', 'kibana', 'myCommitSha', 'api.github.com')
+      getCommitBySha({
+        repoOwner: 'elastic',
+        repoName: 'kibana',
+        sha: 'myCommitSha',
+        apiHostname: 'api.github.com'
+      } as BackportOptions & { sha: string })
     ).rejects.toThrowError('No commit found for SHA: myCommitSha');
   });
 
@@ -64,7 +70,12 @@ describe('getCommitBySha', () => {
       });
 
     expect(
-      await getCommitBySha('elastic', 'kibana', 'myCommitSha', 'api.github.com')
+      await getCommitBySha({
+        repoOwner: 'elastic',
+        repoName: 'kibana',
+        sha: 'myCommitSha',
+        apiHostname: 'api.github.com'
+      } as BackportOptions & { sha: string })
     ).toEqual({
       message: '[Chrome] Bootstrap Angular into document.body (#15158)',
       pullNumber: 1338,

--- a/test/steps/maybeSetupRepo.test.ts
+++ b/test/steps/maybeSetupRepo.test.ts
@@ -1,6 +1,7 @@
 import rimraf from 'rimraf';
 import * as rpc from '../../src/services/rpc';
 import { maybeSetupRepo } from '../../src/steps/maybeSetupRepo';
+import { BackportOptions } from '../../src/options/options';
 
 describe('maybeSetupRepo', () => {
   it('should delete repo if an error occurs', async () => {
@@ -11,12 +12,12 @@ describe('maybeSetupRepo', () => {
 
     try {
       await maybeSetupRepo({
-        owner: 'elastic',
+        repoOwner: 'elastic',
         repoName: 'kibana',
         username: 'sqren',
         accessToken: 'myAccessToken',
         gitHostname: 'github.com'
-      });
+      } as BackportOptions);
     } catch (e) {
       expect(rimraf).toHaveBeenCalledWith(
         '/myHomeDir/.backport/repositories/elastic/kibana',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4402,10 +4402,10 @@ type-fest@^0.4.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.4.1.tgz#8bdf77743385d8a4f13ba95f610f5ccd68c728f8"
   integrity sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==
 
-typescript@^3.4.4:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.4.tgz#aac4a08abecab8091a75f10842ffa0631818f785"
-  integrity sha512-xt5RsIRCEaf6+j9AyOBgvVuAec0i92rgCaS3S+UVf5Z/vF2Hvtsw08wtUTJqp4djwznoAgjSxeCcU4r+CcDBJA==
+typescript@^3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
A bit of cleanup - no user-facing changes
 - Remove `setAccessToken` setter
 - Preserve `options` object
 - Simplify tests