### PR TITLE
Add `path` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,27 +82,27 @@ The above commands will start an interactive prompt. You can use the `arrow keys
 
 ### CLI arguments
 
-| Option           | Description                                            | Default                         | Type    |
-| ---------------- | ------------------------------------------------------ | ------------------------------- | ------- |
-| --accesstoken    | Github access token                                    |                                 | string  |
-| --all            | Show commits from other than me                        | false                           | boolean |
-| --api-hostname   | Hostname for the Github API                            | api.github.com                  | string  |
-| --author         | Filter commits by author                               | _Current user_                  | string  |
-| --branch         | Branch to backport to                                  |                                 | string  |
-| --commits-count  | Number of commits to choose from                       | 10                              | number  |
-| --editor         | Editor (eg. `code`) to open and solve conflicts        |                                 | string  |
-| --fork           | Create backports in fork (true) or origin repo (false) | true                            | boolean |
-| --git-hostname   | Hostname for Git remotes                               | github.com                      | string  |
-| --labels         | Pull request labels                                    |                                 | string  |
-| --multiple       | Select multiple commits/branches                       | false                           | boolean |
-| --path           | List commits for a specific path                       |                                 | string  |
-| --pr-description | Pull request description suffix                        |                                 | string  |
-| --pr-title       | Pull request title pattern                             | [{baseBranch}] {commitMessages} | string  |
-| --sha            | Sha of commit to backport                              |                                 | string  |
-| --upstream       | Name of organization and repository                    |                                 | string  |
-| --username       | Github username                                        |                                 | string  |
-| --help           | Show help                                              |                                 |         |
-| -v, --version    | Show version number                                    |                                 |         |
+| Option           | Description                                            | Default        | Type    |
+| ---------------- | ------------------------------------------------------ | -------------- | ------- |
+| --accesstoken    | Github access token                                    |                | string  |
+| --all            | Show commits from other than me                        | false          | boolean |
+| --api-hostname   | Hostname for the Github API                            | api.github.com | string  |
+| --author         | Filter commits by author                               | _Current user_ | string  |
+| --branch         | Branch to backport to                                  |                | string  |
+| --commits-count  | Number of commits to choose from                       | 10             | number  |
+| --editor         | Editor (eg. `code`) to open and solve conflicts        |                | string  |
+| --fork           | Create backports in fork (true) or origin repo (false) | true           | boolean |
+| --git-hostname   | Hostname for Git remotes                               | github.com     | string  |
+| --labels         | Pull request labels                                    |                | string  |
+| --multiple       | Select multiple commits/branches                       | false          | boolean |
+| --path           | Only list commits touching files under a specific path |                | string  |
+| --pr-description | Pull request description suffix                        |                | string  |
+| --pr-title       | Pull request title pattern                             |                | string  |
+| --sha            | Sha of commit to backport                              |                | string  |
+| --upstream       | Name of organization and repository                    |                | string  |
+| --username       | Github username                                        |                | string  |
+| --help           | Show help                                              |                |         |
+| -v, --version    | Show version number                                    |                |         |
 
 All of the CLI arguments can also be configured via the [configuration options](https://github.com/sqren/backport/blob/master/docs/configuration.md) in the config files.
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The above commands will start an interactive prompt. You can use the `arrow keys
 | --git-hostname   | Hostname for Git remotes                               | github.com                      | string  |
 | --labels         | Pull request labels                                    |                                 | string  |
 | --multiple       | Select multiple commits/branches                       | false                           | boolean |
+| --path           | List commits for a specific path                       |                                 | string  |
 | --pr-description | Pull request description suffix                        |                                 | string  |
 | --pr-title       | Pull request title pattern                             | [{baseBranch}] {commitMessages} | string  |
 | --sha            | Sha of commit to backport                              |                                 | string  |

--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -77,6 +77,11 @@ export function getOptionsFromCliArgs(
       description: 'Backport to multiple branches',
       type: 'boolean'
     })
+    .option('path', {
+      default: configOptions.path,
+      description: 'List commits for a specific path',
+      type: 'string'
+    })
     .option('prTitle', {
       default: configOptions.prTitle,
       description: 'Title of pull request',
@@ -121,6 +126,7 @@ export function getOptionsFromCliArgs(
     multiple: cliArgs.multiple,
     multipleBranches: cliArgs.multipleBranches || cliArgs.multiple,
     multipleCommits: cliArgs.multipleCommits || cliArgs.multiple,
+    path: cliArgs.path,
     prTitle: cliArgs.prTitle,
     prDescription: cliArgs.prDescription,
     sha: cliArgs.sha,

--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -79,7 +79,7 @@ export function getOptionsFromCliArgs(
     })
     .option('path', {
       default: configOptions.path,
-      description: 'List commits for a specific path',
+      description: 'Only list commits touching files under the specified path',
       type: 'string'
     })
     .option('prTitle', {

--- a/src/services/github/fetchCommitsByAuthor.ts
+++ b/src/services/github/fetchCommitsByAuthor.ts
@@ -67,6 +67,7 @@ export async function fetchCommitsByAuthor(
     accessToken,
     apiHostname,
     commitsCount,
+    path,
     repoName,
     repoOwner
   } = options;
@@ -77,12 +78,17 @@ export async function fetchCommitsByAuthor(
       $repoName: String!
       $commitsCount: Int!
       $authorId: ID
+      $historyPath: String
     ) {
       repository(owner: $repoOwner, name: $repoName) {
         ref(qualifiedName: "master") {
           target {
             ... on Commit {
-              history(first: $commitsCount, author: { id: $authorId }) {
+              history(
+                first: $commitsCount
+                author: { id: $authorId }
+                path: $historyPath
+              ) {
                 edges {
                   node {
                     oid
@@ -140,7 +146,8 @@ export async function fetchCommitsByAuthor(
       repoOwner,
       repoName,
       commitsCount: commitsCount || 10,
-      authorId
+      authorId,
+      historyPath: path || null
     }
   });
 

--- a/src/steps/getCommits.ts
+++ b/src/steps/getCommits.ts
@@ -33,9 +33,13 @@ async function getCommitsByPrompt(options: BackportOptions) {
   try {
     const commits = await fetchCommitsByAuthor(options);
     if (isEmpty(commits)) {
+      const pathText = options.path
+        ? ` touching files in path: "${options.path}"`
+        : '';
+
       const warningText = options.all
-        ? 'There are no commits in this repository'
-        : `There are no commits by "${options.author}" in this repository. Try with \`--all\` for commits by all users or \`--author=<username>\` for commits from a specific user`;
+        ? `There are no commits in this repository${pathText}`
+        : `There are no commits by "${options.author}" in this repository${pathText}. Try with \`--all\` for commits by all users or \`--author=<username>\` for commits from a specific user`;
 
       spinner.fail(warningText);
       process.exit(1);

--- a/src/types/Config.ts
+++ b/src/types/Config.ts
@@ -24,6 +24,7 @@ export interface Config {
   multiple?: boolean;
   multipleBranches?: boolean;
   multipleCommits?: boolean;
+  path?: string;
   prDescription?: string;
   prTitle?: string;
 }

--- a/test/integration/__snapshots__/integration.test.ts.snap
+++ b/test/integration/__snapshots__/integration.test.ts.snap
@@ -23,12 +23,17 @@ Object {
       $repoName: String!
       $commitsCount: Int!
       $authorId: ID
+      $historyPath: String
     ) {
       repository(owner: $repoOwner, name: $repoName) {
         ref(qualifiedName: \\"master\\") {
           target {
             ... on Commit {
-              history(first: $commitsCount, author: { id: $authorId }) {
+              history(
+                first: $commitsCount
+                author: { id: $authorId }
+                path: $historyPath
+              ) {
                 edges {
                   node {
                     oid
@@ -79,6 +84,7 @@ Object {
   "variables": Object {
     "authorId": "sqren_author_id",
     "commitsCount": 10,
+    "historyPath": null,
     "repoName": "backport-demo",
     "repoOwner": "elastic",
   },
@@ -119,12 +125,17 @@ Object {
       $repoName: String!
       $commitsCount: Int!
       $authorId: ID
+      $historyPath: String
     ) {
       repository(owner: $repoOwner, name: $repoName) {
         ref(qualifiedName: \\"master\\") {
           target {
             ... on Commit {
-              history(first: $commitsCount, author: { id: $authorId }) {
+              history(
+                first: $commitsCount
+                author: { id: $authorId }
+                path: $historyPath
+              ) {
                 edges {
                   node {
                     oid
@@ -175,6 +186,7 @@ Object {
   "variables": Object {
     "authorId": "sqren_author_id",
     "commitsCount": 10,
+    "historyPath": null,
     "repoName": "backport-demo",
     "repoOwner": "elastic",
   },

--- a/test/unit/options/options.test.ts
+++ b/test/unit/options/options.test.ts
@@ -16,6 +16,7 @@ const validOptions: OptionsFromCliArgs = {
   multiple: false,
   multipleBranches: true,
   multipleCommits: false,
+  path: undefined,
   prTitle: 'myPrTitle',
   prDescription: undefined,
   sha: undefined,

--- a/test/unit/services/github/__snapshots__/fetchCommitsByAuthor.test.ts.snap
+++ b/test/unit/services/github/__snapshots__/fetchCommitsByAuthor.test.ts.snap
@@ -30,12 +30,17 @@ Array [
       $repoName: String!
       $commitsCount: Int!
       $authorId: ID
+      $historyPath: String
     ) {
       repository(owner: $repoOwner, name: $repoName) {
         ref(qualifiedName: \\"master\\") {
           target {
             ... on Commit {
-              history(first: $commitsCount, author: { id: $authorId }) {
+              history(
+                first: $commitsCount
+                author: { id: $authorId }
+                path: $historyPath
+              ) {
                 edges {
                   node {
                     oid
@@ -86,6 +91,7 @@ Array [
     "variables": Object {
       "authorId": "myUserId",
       "commitsCount": 10,
+      "historyPath": null,
       "repoName": "kibana",
       "repoOwner": "elastic",
     },

--- a/test/unit/steps/__snapshots__/steps.test.ts.snap
+++ b/test/unit/steps/__snapshots__/steps.test.ts.snap
@@ -203,12 +203,17 @@ exports[`run through steps should make correct POST requests 1`] = `
       $repoName: String!
       $commitsCount: Int!
       $authorId: ID
+      $historyPath: String
     ) {
       repository(owner: $repoOwner, name: $repoName) {
         ref(qualifiedName: \\"master\\") {
           target {
             ... on Commit {
-              history(first: $commitsCount, author: { id: $authorId }) {
+              history(
+                first: $commitsCount
+                author: { id: $authorId }
+                path: $historyPath
+              ) {
                 edges {
                   node {
                     oid
@@ -259,6 +264,7 @@ exports[`run through steps should make correct POST requests 1`] = `
         "variables": Object {
           "authorId": "sqren_author_id",
           "commitsCount": 10,
+          "historyPath": null,
           "repoName": "kibana",
           "repoOwner": "elastic",
         },

--- a/test/unit/steps/steps.test.ts
+++ b/test/unit/steps/steps.test.ts
@@ -41,6 +41,7 @@ describe('run through steps', () => {
       multiple: false,
       multipleBranches: false,
       multipleCommits: false,
+      path: undefined,
       prDescription: 'myPrDescription',
       prTitle: 'myPrTitle {baseBranch} {commitMessages}',
       repoName: 'kibana',


### PR DESCRIPTION
This makes it possible to only list commits that touches files under a specified path.

Example usage:
```
backport --all --path x-pack/legacy/plugins/apm
```