### PR TITLE
Add `--reset-author` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The above commands will start an interactive prompt. You can use the `arrow keys
 | --pr-description | Pull request description suffix                        |                | string  |
 | --pr-title       | Pull request title pattern                             |                | string  |
 | --pr             | Pull request to backport                               |                | number  |
+| --resetAuthor    | Set yourself as commit author                          |                | boolean |
 | --sha            | Sha of commit to backport                              |                | string  |
 | --upstream       | Name of organization and repository                    |                | string  |
 | --username       | Github username                                        |                | string  |

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The above commands will start an interactive prompt. You can use the `arrow keys
 | --pr-description | Pull request description suffix                        |                | string  |
 | --pr-title       | Pull request title pattern                             |                | string  |
 | --pr             | Pull request to backport                               |                | number  |
-| --resetAuthor    | Set yourself as commit author                          |                | boolean |
+| --reset-author   | Set yourself as commit author                          |                | boolean |
 | --sha            | Sha of commit to backport                              |                | string  |
 | --upstream       | Name of organization and repository                    |                | string  |
 | --username       | Github username                                        |                | string  |

--- a/src/options/cliArgs.test.ts
+++ b/src/options/cliArgs.test.ts
@@ -49,6 +49,7 @@ describe('getOptionsFromCliArgs', () => {
       multipleBranches: true,
       multipleCommits: false,
       prTitle: 'myPrTitle',
+      resetAuthor: false,
       sha: undefined,
       upstream: 'sqren/backport-demo',
       username: 'sqren'

--- a/src/options/cliArgs.test.ts
+++ b/src/options/cliArgs.test.ts
@@ -1,9 +1,8 @@
 import { getOptionsFromCliArgs } from './cliArgs';
+import { OptionsFromConfigFiles } from './config/config';
 
 describe('getOptionsFromCliArgs', () => {
-  let res: ReturnType<typeof getOptionsFromCliArgs>;
-
-  beforeEach(async () => {
+  it('should return correct options', () => {
     const configOptions = {
       accessToken: 'myAccessToken',
       all: false,
@@ -32,10 +31,8 @@ describe('getOptionsFromCliArgs', () => {
       'sqren'
     ];
 
-    res = getOptionsFromCliArgs(configOptions, argv);
-  });
+    const res = getOptionsFromCliArgs(configOptions, argv);
 
-  it('should return correct options', () => {
     expect(res).toEqual({
       accessToken: 'myAccessToken',
       all: true,
@@ -54,5 +51,32 @@ describe('getOptionsFromCliArgs', () => {
       upstream: 'sqren/backport-demo',
       username: 'sqren'
     });
+  });
+
+  it('should accept both camel-case and dashed-case and convert them to camel cased', () => {
+    const configOptions = {} as OptionsFromConfigFiles;
+    const argv = [
+      '--access-token',
+      'my access token',
+      '--apiHostname',
+      'my api hostname'
+    ];
+
+    const res = getOptionsFromCliArgs(configOptions, argv);
+
+    expect(res.accessToken).toEqual('my access token');
+    expect('access-token' in res).toEqual(false);
+    expect(res.apiHostname).toEqual('my api hostname');
+    expect('api-hostname' in res).toEqual(false);
+  });
+
+  it('should accept aliases (--pr) but only return the full name (--pullNumber) in the result', () => {
+    const configOptions = {} as OptionsFromConfigFiles;
+    const argv = ['--pr', '1337'];
+
+    const res = getOptionsFromCliArgs(configOptions, argv);
+
+    expect(res.pullNumber).toEqual(1337);
+    expect('pr' in res).toEqual(false);
   });
 });

--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -97,6 +97,11 @@ export function getOptionsFromCliArgs(
       type: 'number',
       alias: 'pr'
     })
+    .option('resetAuthor', {
+      default: false,
+      description: 'Set yourself as commit author',
+      type: 'boolean'
+    })
     .option('sha', {
       description: 'Commit sha to backport',
       type: 'string',
@@ -135,6 +140,7 @@ export function getOptionsFromCliArgs(
     prTitle: cliArgs.prTitle,
     prDescription: cliArgs.prDescription,
     pullNumber: cliArgs.pullNumber,
+    resetAuthor: cliArgs.resetAuthor,
     sha: cliArgs.sha,
     upstream: cliArgs.upstream,
     username: cliArgs.username

--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -7,6 +7,10 @@ export function getOptionsFromCliArgs(
   argv: string[]
 ) {
   const cliArgs = yargs(argv)
+    .parserConfiguration({
+      'strip-dashed': true,
+      'strip-aliased': true
+    })
     .usage('$0 [args]')
     .wrap(Math.max(100, Math.min(120, yargs.terminalWidth())))
     .option('accessToken', {
@@ -121,28 +125,13 @@ export function getOptionsFromCliArgs(
     .version()
     .help().argv;
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { $0, _, ...rest } = cliArgs;
+
   return {
-    accessToken: cliArgs.accessToken,
-    all: cliArgs.all,
-    apiHostname: cliArgs.apiHostname,
-    author: cliArgs.author,
-    commitsCount: cliArgs.commitsCount,
+    ...rest,
     branchChoices: configOptions.branchChoices,
-    branches: cliArgs.branches,
-    editor: cliArgs.editor,
-    fork: cliArgs.fork,
-    gitHostname: cliArgs.gitHostname,
-    labels: cliArgs.labels,
-    multiple: cliArgs.multiple,
     multipleBranches: cliArgs.multipleBranches || cliArgs.multiple,
-    multipleCommits: cliArgs.multipleCommits || cliArgs.multiple,
-    path: cliArgs.path,
-    prTitle: cliArgs.prTitle,
-    prDescription: cliArgs.prDescription,
-    pullNumber: cliArgs.pullNumber,
-    resetAuthor: cliArgs.resetAuthor,
-    sha: cliArgs.sha,
-    upstream: cliArgs.upstream,
-    username: cliArgs.username
+    multipleCommits: cliArgs.multipleCommits || cliArgs.multiple
   };
 }

--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -7,10 +7,11 @@ export function getOptionsFromCliArgs(
   argv: string[]
 ) {
   const cliArgs = yargs(argv)
+    // TODO: remove `any` downcast as soon as this PR is merged: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38108
     .parserConfiguration({
       'strip-dashed': true,
       'strip-aliased': true
-    })
+    } as any)
     .usage('$0 [args]')
     .wrap(Math.max(100, Math.min(120, yargs.terminalWidth())))
     .option('accessToken', {

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -20,6 +20,7 @@ const validOptions: OptionsFromCliArgs = {
   prDescription: undefined,
   prTitle: 'myPrTitle',
   pullNumber: undefined,
+  resetAuthor: false,
   sha: undefined,
   upstream: 'elastic/kibana',
   username: 'sqren'

--- a/src/services/git.ts
+++ b/src/services/git.ts
@@ -103,6 +103,15 @@ export function cherrypick(options: BackportOptions, commitSha: string) {
   );
 }
 
+export function setCommitAuthor(options: BackportOptions, username: string) {
+  return exec(
+    `git commit --amend --no-edit --author "${username} <${username}@users.noreply.github.com>"`,
+    {
+      cwd: getRepoPath(options)
+    }
+  );
+}
+
 export async function isIndexDirty(options: BackportOptions) {
   try {
     await exec(`git diff-index --quiet HEAD --`, {

--- a/src/steps/doBackportVersions.ts
+++ b/src/steps/doBackportVersions.ts
@@ -10,7 +10,8 @@ import {
   deleteFeatureBranch,
   isIndexDirty,
   pushFeatureBranch,
-  getRemoteName
+  getRemoteName,
+  setCommitAuthor
 } from '../services/git';
 import { confirmPrompt } from '../services/prompts';
 import { createPullRequest } from '../services/github/createPullRequest';
@@ -65,6 +66,13 @@ export async function doBackportVersion(
   await sequentially(commits, commit =>
     cherrypickAndConfirm(options, commit.sha)
   );
+
+  if (options.resetAuthor) {
+    await withSpinner(
+      { text: `Changing author to "${options.username}"` },
+      () => setCommitAuthor(options, options.username)
+    );
+  }
 
   const headBranchName = getHeadBranchName(options, featureBranch);
 

--- a/src/steps/steps.test.ts
+++ b/src/steps/steps.test.ts
@@ -46,6 +46,7 @@ describe('run through steps', () => {
       pullNumber: undefined,
       repoName: 'kibana',
       repoOwner: 'elastic',
+      resetAuthor: false,
       sha: undefined,
       username: 'sqren'
     };


### PR DESCRIPTION
Closes #146

Add `--reset-author` flag which makes it possible to change the commit author to yourself.
This is useful when the original commit was made by a bot and the the CLA check needs to be bypassed.

Example usage:
```
backport --reset-author
```

@spalger 