### PR TITLE
Fix “accessToken” options typo

### DIFF
--- a/src/options/__snapshots__/options.test.ts.snap
+++ b/src/options/__snapshots__/options.test.ts.snap
@@ -2,14 +2,14 @@
 
 exports[`validateRequiredOptions should throw when accessToken is empty 1`] = `
 "Please update your config file: /myHomeDir/.backport/config.json.
-It must contain a valid \\"username\\" and \\"acccessToken\\".
+It must contain a valid \\"username\\" and \\"accessToken\\".
 
 Read more: https://github.com/sqren/backport/blob/f0535241177c5b343b04fe12844bfb513237d847/docs/configuration.md#global-config-backportconfigjson"
 `;
 
 exports[`validateRequiredOptions should throw when accessToken is missing 1`] = `
 "Please update your config file: /myHomeDir/.backport/config.json.
-It must contain a valid \\"username\\" and \\"acccessToken\\".
+It must contain a valid \\"username\\" and \\"accessToken\\".
 
 Read more: https://github.com/sqren/backport/blob/f0535241177c5b343b04fe12844bfb513237d847/docs/configuration.md#global-config-backportconfigjson"
 `;
@@ -40,14 +40,14 @@ You can add it with either:
 
 exports[`validateRequiredOptions should throw when username is empty 1`] = `
 "Please update your config file: /myHomeDir/.backport/config.json.
-It must contain a valid \\"username\\" and \\"acccessToken\\".
+It must contain a valid \\"username\\" and \\"accessToken\\".
 
 Read more: https://github.com/sqren/backport/blob/f0535241177c5b343b04fe12844bfb513237d847/docs/configuration.md#global-config-backportconfigjson"
 `;
 
 exports[`validateRequiredOptions should throw when username is missing 1`] = `
 "Please update your config file: /myHomeDir/.backport/config.json.
-It must contain a valid \\"username\\" and \\"acccessToken\\".
+It must contain a valid \\"username\\" and \\"accessToken\\".
 
 Read more: https://github.com/sqren/backport/blob/f0535241177c5b343b04fe12844bfb513237d847/docs/configuration.md#global-config-backportconfigjson"
 `;

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -35,7 +35,7 @@ export function validateRequiredOptions({
   if (!options.accessToken || !options.username) {
     const globalConfigPath = getGlobalConfigPath();
     throw new HandledError(
-      `Please update your config file: ${globalConfigPath}.\nIt must contain a valid "username" and "acccessToken".\n\nRead more: ${GLOBAL_CONFIG_DOCS_LINK}`
+      `Please update your config file: ${globalConfigPath}.\nIt must contain a valid "username" and "accessToken".\n\nRead more: ${GLOBAL_CONFIG_DOCS_LINK}`
     );
   }
 


### PR DESCRIPTION
Previously the CLI would display the error message with `acccessToken`, which doesn't match the actual param name.