### PR TITLE
Send access token via auth header

### DIFF
--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -35,7 +35,8 @@ describe('getOptions', () => {
   it('should check whether access token is valid', () => {
     expect(axiosHeadSpy).toHaveBeenCalledTimes(1);
     expect(axiosHeadSpy).toHaveBeenCalledWith(
-      'https://api.github.com/repos/elastic/kibana?access_token=myAccessToken'
+      'https://api.github.com/repos/elastic/kibana',
+      { auth: { password: 'myAccessToken', username: 'sqren' } }
     );
   });
 

--- a/src/services/github/__snapshots__/fetchCommitBySha.test.ts.snap
+++ b/src/services/github/__snapshots__/fetchCommitBySha.test.ts.snap
@@ -3,8 +3,12 @@
 exports[`fetchCommitBySha should return single commit with pull request 1`] = `
 Array [
   Array [
-    "https://api.github.com/search/commits?q=hash:sha123456789%20repo:elastic/kibana&per_page=1&access_token=myAccessToken",
+    "https://api.github.com/search/commits?q=hash:sha123456789%20repo:elastic/kibana&per_page=1",
     Object {
+      "auth": Object {
+        "password": "myAccessToken",
+        "username": "sqren",
+      },
       "headers": Object {
         "Accept": "application/vnd.github.cloak-preview",
       },

--- a/src/services/github/addLabelsToPullRequest.ts
+++ b/src/services/github/addLabelsToPullRequest.ts
@@ -4,7 +4,7 @@ import { handleGithubError } from './handleGithubError';
 import { logger } from '../logger';
 
 export async function addLabelsToPullRequest(
-  { apiHostname, repoName, repoOwner, accessToken }: BackportOptions,
+  { apiHostname, repoName, repoOwner, accessToken, username }: BackportOptions,
   pullNumber: number,
   labels: string[]
 ) {
@@ -12,8 +12,14 @@ export async function addLabelsToPullRequest(
 
   try {
     return await axios.post(
-      `https://${apiHostname}/repos/${repoOwner}/${repoName}/issues/${pullNumber}/labels?access_token=${accessToken}`,
-      labels
+      `https://${apiHostname}/repos/${repoOwner}/${repoName}/issues/${pullNumber}/labels`,
+      labels,
+      {
+        auth: {
+          username: username,
+          password: accessToken
+        }
+      }
     );
   } catch (e) {
     throw handleGithubError(e);

--- a/src/services/github/createPullRequest.ts
+++ b/src/services/github/createPullRequest.ts
@@ -5,7 +5,7 @@ import { handleGithubError } from './handleGithubError';
 import { logger } from '../logger';
 
 export async function createPullRequest(
-  { apiHostname, repoName, repoOwner, accessToken }: BackportOptions,
+  { apiHostname, repoName, repoOwner, accessToken, username }: BackportOptions,
   payload: {
     title: string;
     body: string;
@@ -19,8 +19,14 @@ export async function createPullRequest(
 
   try {
     const res: AxiosResponse<GithubIssue> = await axios.post(
-      `https://${apiHostname}/repos/${repoOwner}/${repoName}/pulls?access_token=${accessToken}`,
-      payload
+      `https://${apiHostname}/repos/${repoOwner}/${repoName}/pulls`,
+      payload,
+      {
+        auth: {
+          username: username,
+          password: accessToken
+        }
+      }
     );
     return {
       html_url: res.data.html_url,

--- a/src/services/github/fetchCommitBySha.ts
+++ b/src/services/github/fetchCommitBySha.ts
@@ -10,11 +10,22 @@ import { getFormattedCommitMessage } from './commitFormatters';
 export async function fetchCommitBySha(
   options: BackportOptions & { sha: string }
 ): Promise<CommitSelected> {
-  const { apiHostname, repoName, repoOwner, sha, accessToken } = options;
+  const {
+    apiHostname,
+    repoName,
+    repoOwner,
+    sha,
+    accessToken,
+    username
+  } = options;
   try {
     const res = await axios.get<GithubSearch<GithubCommit>>(
-      `https://${apiHostname}/search/commits?q=hash:${sha}%20repo:${repoOwner}/${repoName}&per_page=1&access_token=${accessToken}`,
+      `https://${apiHostname}/search/commits?q=hash:${sha}%20repo:${repoOwner}/${repoName}&per_page=1`,
       {
+        auth: {
+          username: username,
+          password: accessToken
+        },
         headers: {
           Accept: 'application/vnd.github.cloak-preview'
         }

--- a/src/services/github/verifyAccessToken.test.ts
+++ b/src/services/github/verifyAccessToken.test.ts
@@ -19,7 +19,8 @@ describe('verifyAccessToken', () => {
     await verifyAccessToken(getDefaultOptions(options));
 
     expect(spy).toHaveBeenCalledWith(
-      'https://api.github.com/repos/elastic/kibana?access_token=myAccessToken'
+      'https://api.github.com/repos/elastic/kibana',
+      { auth: { password: 'myAccessToken', username: 'sqren' } }
     );
   });
 

--- a/src/services/github/verifyAccessToken.ts
+++ b/src/services/github/verifyAccessToken.ts
@@ -15,6 +15,7 @@ function getSSOAuthUrl(error: GithubApiError) {
 }
 
 export async function verifyAccessToken({
+  username,
   accessToken,
   apiHostname,
   repoName,
@@ -22,7 +23,13 @@ export async function verifyAccessToken({
 }: ReturnType<typeof validateRequiredOptions>) {
   try {
     return await axios.head(
-      `https://${apiHostname}/repos/${repoOwner}/${repoName}?access_token=${accessToken}`
+      `https://${apiHostname}/repos/${repoOwner}/${repoName}`,
+      {
+        auth: {
+          username: username,
+          password: accessToken
+        }
+      }
     );
   } catch (e) {
     const error = e as GithubApiError;

--- a/src/ui/cherrypickAndCreatePullRequest.test.ts
+++ b/src/ui/cherrypickAndCreatePullRequest.test.ts
@@ -75,7 +75,7 @@ describe('cherrypickAndCreatePullRequest', () => {
       expect(axiosPostMock).toHaveBeenCalledTimes(2);
       const [apiEndpoint, payload] = axiosPostMock.mock.calls[0];
       expect(apiEndpoint).toBe(
-        'https://api.github.com/repos/elastic/kibana/pulls?access_token=undefined'
+        'https://api.github.com/repos/elastic/kibana/pulls'
       );
       expect(payload.title).toBe(
         '[6.x] myCommitMessage (#1000) | myOtherCommitMessage (#2000)'
@@ -95,7 +95,7 @@ myPrSuffix`
       const [apiEndpoint, labels] = axiosPostMock.mock.calls[1];
 
       expect(apiEndpoint).toBe(
-        'https://api.github.com/repos/elastic/kibana/issues/1337/labels?access_token=undefined'
+        'https://api.github.com/repos/elastic/kibana/issues/1337/labels'
       );
       expect(labels).toEqual(['backport']);
     });
@@ -126,7 +126,7 @@ myPrSuffix`
       expect(axiosPostMock).toHaveBeenCalledTimes(2);
       const [apiEndpoint, payload] = axiosPostMock.mock.calls[0];
       expect(apiEndpoint).toBe(
-        'https://api.github.com/repos/elastic/kibana/pulls?access_token=undefined'
+        'https://api.github.com/repos/elastic/kibana/pulls'
       );
       expect(payload.title).toBe('[6.x] myCommitMessage (mySha)');
       expect(payload.body).toBe(
@@ -141,7 +141,7 @@ myPrSuffix`
       const [apiEndpoint, labels] = axiosPostMock.mock.calls[1];
 
       expect(apiEndpoint).toBe(
-        'https://api.github.com/repos/elastic/kibana/issues/1337/labels?access_token=undefined'
+        'https://api.github.com/repos/elastic/kibana/issues/1337/labels'
       );
       expect(labels).toEqual(['backport']);
     });

--- a/src/ui/getCommitBySha.test.ts
+++ b/src/ui/getCommitBySha.test.ts
@@ -10,6 +10,8 @@ describe('getCommitBySha', () => {
   it('should return a single commit without PR', async () => {
     const axiosSpy = mockCommitItems([commitByShaMock]);
     const commit = await getCommitBySha({
+      username: 'sqren',
+      accessToken: 'myAccessToken',
       repoOwner: 'elastic',
       repoName: 'kibana',
       sha: 'myCommitSha',
@@ -24,8 +26,11 @@ describe('getCommitBySha', () => {
     });
 
     expect(axiosSpy).toHaveBeenCalledWith(
-      'https://api.github.com/search/commits?q=hash:myCommitSha%20repo:elastic/kibana&per_page=1&access_token=undefined',
-      { headers: { Accept: 'application/vnd.github.cloak-preview' } }
+      'https://api.github.com/search/commits?q=hash:myCommitSha%20repo:elastic/kibana&per_page=1',
+      {
+        headers: { Accept: 'application/vnd.github.cloak-preview' },
+        auth: { password: 'myAccessToken', username: 'sqren' }
+      }
     );
   });
 


### PR DESCRIPTION
Github is deprecating sending access token via query param. Instead it should be sent over auth header

https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters

Closes #164