### PR TITLE
print the repo path on conflicts

### DIFF
--- a/src/ui/cherrypickAndCreatePullRequest.test.ts
+++ b/src/ui/cherrypickAndCreatePullRequest.test.ts
@@ -235,7 +235,7 @@ describe('cherrypickAndCreateTargetPullRequest', () => {
       expect(promptSpy.mock.calls).toMatchInlineSnapshot(`
         Array [
           Array [
-            "The following files have conflicts:
+            "The following files from /myHomeDir/.backport/repositories/elastic/kibana have conflicts:
          - /myHomeDir/.backport/repositories/elastic/kibana/conflicting-file.txt
 
         You do not need to \`git add\` or \`git commit\` the files - simply fix the conflicts.
@@ -243,7 +243,7 @@ describe('cherrypickAndCreateTargetPullRequest', () => {
         Press ENTER when the conflicts are resolved",
           ],
           Array [
-            "The following files have conflicts:
+            "The following files from /myHomeDir/.backport/repositories/elastic/kibana have conflicts:
          - /myHomeDir/.backport/repositories/elastic/kibana/conflicting-file.txt
 
         You do not need to \`git add\` or \`git commit\` the files - simply fix the conflicts.

--- a/src/ui/cherrypickAndCreateTargetPullRequest.ts
+++ b/src/ui/cherrypickAndCreateTargetPullRequest.ts
@@ -165,7 +165,9 @@ async function listConflictingFiles(options: BackportOptions) {
     consoleLog(''); // linebreak
     const res = await confirmPrompt(
       dedent(`
-        ${chalk.reset(`The following files have conflicts:`)}
+        ${chalk.reset(
+          `The following files from ${getRepoPath(options)} have conflicts:`
+        )}
         ${chalk.reset(filesWithConflicts.join('\n'))}
 
         ${chalk.reset.italic(


### PR DESCRIPTION
Closes #193 

Prints the repo path before the files which are conflicting to make it easier to open the entire repo when desired.