### PR TITLE
Add options: `auto-assign` and `assignees`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ See [configuration.md](https://github.com/sqren/backport/blob/master/docs/config
 | --accesstoken      | Github access token                                    |                | string  |
 | --all              | Show commits from other than me                        | false          | boolean |
 | --author           | Filter commits by author                               | _Current user_ | string  |
+| --assignees        | Assign users to target pull request                    |                | string  |
+| --auto-assign      | Assign current user to target pull request             | false          | boolean |
 | --branch           | Target branch to backport to                           |                | string  |
 | --dry-run          | Perform backport without pushing to Github             | false          | boolean |
 | --editor           | Editor (eg. `code`) to open and solve conflicts        |                | string  |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,6 +119,34 @@ Default: `false`
 
 CLI: `--all`, `-a`
 
+#### `assignees`
+
+Add assignees to the target pull request
+
+CLI: `--assignees <username>`, `-assign <username>`
+
+Config:
+
+```json
+{
+  "assignees": ["sqren"]
+}
+```
+
+#### `autoAssign`
+
+Automatically add the current user as assignee to the target pull request
+
+CLI: `--auto-assign`
+
+Config:
+
+```json
+{
+  "autoAssign": true
+}
+```
+
 #### `branchLabelMapping`
 
 Pre-select target branch choices based on the source PR labels.

--- a/src/options/cliArgs.test.ts
+++ b/src/options/cliArgs.test.ts
@@ -1,9 +1,8 @@
-import { getOptionsFromCliArgs } from './cliArgs';
-import { OptionsFromConfigFiles } from './config/config';
+import { getOptionsFromCliArgs, OptionsFromCliArgs } from './cliArgs';
 
 describe('getOptionsFromCliArgs', () => {
   it('should return correct options', () => {
-    const configOptions = {
+    const configOptions: Partial<OptionsFromCliArgs> = {
       accessToken: 'myAccessToken',
       all: false,
       fork: true,
@@ -39,6 +38,7 @@ describe('getOptionsFromCliArgs', () => {
     expect(res).toEqual({
       accessToken: 'myAccessToken',
       all: true,
+      assignees: [],
       dryRun: false,
       fork: true,
       gitHostname: 'github.com',
@@ -62,7 +62,7 @@ describe('getOptionsFromCliArgs', () => {
   });
 
   it('should accept both camel-case and dashed-case and convert them to camel cased', () => {
-    const configOptions = {} as OptionsFromConfigFiles;
+    const configOptions: Partial<OptionsFromCliArgs> = {};
     const argv = [
       '--access-token',
       'my access token',
@@ -79,7 +79,7 @@ describe('getOptionsFromCliArgs', () => {
   });
 
   it('should accept aliases (--pr) but only return the full name (--pullNumber) in the result', () => {
-    const configOptions = {} as OptionsFromConfigFiles;
+    const configOptions: Partial<OptionsFromCliArgs> = {};
     const argv = ['--pr', '1337'];
 
     const res = getOptionsFromCliArgs(configOptions, argv);

--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -45,6 +45,19 @@ export function getOptionsFromCliArgs(
       type: 'string',
     })
 
+    .option('assignees', {
+      default: (configOptions.assignees || []) as string[],
+      description: 'Add assignees to the target pull request',
+      alias: ['assignee', 'assign'],
+      type: 'array',
+    })
+
+    .option('autoAssign', {
+      default: (configOptions.autoAssign ?? false) as boolean,
+      description: 'Auto assign the target pull request to yourself',
+      type: 'boolean',
+    })
+
     .option('dryRun', {
       default: false,
       description: 'Perform backport without pushing to Github',
@@ -266,10 +279,13 @@ export function getOptionsFromCliArgs(
     ).argv;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-  const { $0, _, verify, multiple, ...rest } = cliArgs;
+  const { $0, _, verify, multiple, autoAssign, ...rest } = cliArgs;
 
   return {
     ...rest,
+
+    // auto-assign the current user to the target pull request or the assignees specified
+    assignees: autoAssign ? [rest.username as string] : rest.assignees,
 
     // `branchLabelMapping` is not available as cli argument
     branchLabelMapping: configOptions.branchLabelMapping as BranchLabelMapping,

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -107,6 +107,7 @@ describe('validateRequiredOptions', () => {
     accessToken: 'myAccessToken',
     all: false,
     author: undefined,
+    assignees: [],
     branchLabelMapping: undefined,
     dryRun: false,
     editor: 'code',

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -75,6 +75,7 @@ describe('getOptions', () => {
       accessToken: 'myAccessToken',
       all: false,
       author: 'sqren',
+      assignees: [],
       dryRun: false,
       fork: true,
       gitHostname: 'github.com',

--- a/src/runWithOptions.test.ts
+++ b/src/runWithOptions.test.ts
@@ -23,6 +23,7 @@ describe('runWithOptions', () => {
       accessToken: 'myAccessToken',
       all: false,
       author: 'sqren',
+      assignees: [],
       branchLabelMapping: undefined,
       dryRun: false,
       editor: 'code',

--- a/src/services/github/v3/addAssigneesToPullRequest.test.ts
+++ b/src/services/github/v3/addAssigneesToPullRequest.test.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import { BackportOptions } from '../../../options/options';
+import { addAssigneesToPullRequest } from './addAssigneesToPullRequest';
+
+describe('addAssigneesToPullRequest', () => {
+  it('should add assignees to PR', async () => {
+    const pullNumber = 216;
+    const assignees = ['sqren'];
+
+    const spy = jest
+      .spyOn(axios, 'request')
+      .mockResolvedValueOnce('some-response');
+
+    await addAssigneesToPullRequest(
+      {
+        githubApiBaseUrlV3: 'https://api.github.com',
+        repoName: 'backport-demo',
+        repoOwner: 'sqren',
+        accessToken: 'my-token',
+        username: 'sqren',
+        dryRun: false,
+      } as BackportOptions,
+      pullNumber,
+      assignees
+    );
+
+    expect(spy).toHaveBeenCalledWith({
+      method: 'post',
+      url:
+        'https://api.github.com/repos/sqren/backport-demo/issues/216/assignees',
+      auth: { username: 'sqren', password: 'my-token' },
+      data: { assignees: ['sqren'] },
+    });
+  });
+});

--- a/src/services/github/v3/addAssigneesToPullRequest.ts
+++ b/src/services/github/v3/addAssigneesToPullRequest.ts
@@ -1,0 +1,46 @@
+import ora from 'ora';
+import { BackportOptions } from '../../../options/options';
+import { logger } from '../../logger';
+import { apiRequestV3 } from './apiRequestV3';
+
+export async function addAssigneesToPullRequest(
+  {
+    githubApiBaseUrlV3,
+    repoName,
+    repoOwner,
+    accessToken,
+    username,
+    dryRun,
+  }: BackportOptions,
+  pullNumber: number,
+  assignees: string[]
+): Promise<void> {
+  const isSelfAssigning = assignees.length === 1 && assignees[0] === username;
+
+  const text = isSelfAssigning
+    ? `Self-assigning to #${pullNumber}`
+    : `Adding assignees to #${pullNumber}: ${assignees.join(', ')}`;
+  logger.info(text);
+  const spinner = ora(text).start();
+
+  try {
+    if (dryRun) {
+      spinner.succeed(`Dry run: ${text}`);
+      return;
+    }
+
+    await apiRequestV3({
+      method: 'post',
+      url: `${githubApiBaseUrlV3}/repos/${repoOwner}/${repoName}/issues/${pullNumber}/assignees`,
+      data: { assignees },
+      auth: {
+        username: username,
+        password: accessToken,
+      },
+    });
+    spinner.succeed();
+  } catch (e) {
+    spinner.fail();
+    logger.info(`Could not add assignees to PR ${pullNumber}`, e.stack);
+  }
+}

--- a/src/services/github/v3/createPullRequest.ts
+++ b/src/services/github/v3/createPullRequest.ts
@@ -31,7 +31,7 @@ export async function createPullRequest(
   const spinner = ora(`Creating pull request`).start();
 
   if (dryRun) {
-    spinner.succeed();
+    spinner.succeed('Dry run: Creating pull request');
     return { html_url: 'example_url', number: 1337 };
   }
 

--- a/src/test/integration/__snapshots__/integration.test.ts.snap
+++ b/src/test/integration/__snapshots__/integration.test.ts.snap
@@ -176,6 +176,7 @@ Array [
     Object {
       "accessToken": "myAccessToken",
       "all": false,
+      "assignees": Array [],
       "author": "sqren",
       "branchLabelMapping": undefined,
       "dryRun": false,

--- a/src/ui/cherrypickAndCreatePullRequest.test.ts
+++ b/src/ui/cherrypickAndCreatePullRequest.test.ts
@@ -43,6 +43,7 @@ describe('cherrypickAndCreateTargetPullRequest', () => {
         .mockResolvedValue({ stdout: '', stderr: '' });
 
       const options = {
+        assignees: [] as string[],
         githubApiBaseUrlV3: 'https://api.github.com',
         fork: true,
         targetPRLabels: ['backport'],
@@ -142,6 +143,7 @@ describe('cherrypickAndCreateTargetPullRequest', () => {
   describe('when commit does not have a pull request reference', () => {
     beforeEach(async () => {
       const options = {
+        assignees: [] as string[],
         githubApiBaseUrlV3: 'https://api.github.com',
         fork: true,
         targetPRLabels: ['backport'],
@@ -202,6 +204,7 @@ describe('cherrypickAndCreateTargetPullRequest', () => {
       const execSpy = setupExecSpy();
 
       const options = {
+        assignees: [] as string[],
         fork: true,
         targetPRLabels: ['backport'],
         prTitle: '[{targetBranch}] {commitMessages}',


### PR DESCRIPTION
Closes https://github.com/sqren/backport/issues/188

**Example: assign yourself to the backport pull request**
```
backport --auto-assign
```

if you always want to assign yourself to your backport PRs you can add the following to `.backport/config.json`:
```json
{
  "autoAssign": true
}
```

**Example: assign another user to the backport pull request:**
```
backport --assign watson
```