### PR TITLE
[autoFixConflicts] pass `targetBranch` to handler

### DIFF
--- a/src/options/ConfigOptions.ts
+++ b/src/options/ConfigOptions.ts
@@ -10,10 +10,12 @@ type AutoFixConflictsHandler = ({
   files,
   directory,
   logger,
+  targetBranch,
 }: {
   files: string[];
   directory: string;
   logger: Logger;
+  targetBranch: string;
 }) => boolean | Promise<boolean>;
 
 export interface ConfigOptions {

--- a/src/ui/cherrypickAndCreateTargetPullRequest.ts
+++ b/src/ui/cherrypickAndCreateTargetPullRequest.ts
@@ -39,7 +39,9 @@ export async function cherrypickAndCreateTargetPullRequest({
   consoleLog(`\n${chalk.bold(`Backporting to ${targetBranch}:`)}`);
 
   await createBackportBranch({ options, targetBranch, backportBranch });
-  await sequentially(commits, (commit) => waitForCherrypick(options, commit));
+  await sequentially(commits, (commit) =>
+    waitForCherrypick(options, commit, targetBranch)
+  );
 
   if (options.resetAuthor) {
     await setCommitAuthor(options, options.username);
@@ -117,7 +119,8 @@ export function getBackportBranch(
 
 async function waitForCherrypick(
   options: BackportOptions,
-  commit: CommitSelected
+  commit: CommitSelected,
+  targetBranch: string
 ) {
   const spinnerText = `Cherry-picking: ${chalk.greenBright(
     commit.formattedMessage
@@ -157,6 +160,7 @@ async function waitForCherrypick(
       files: filesWithConflicts,
       directory: repoPath,
       logger,
+      targetBranch,
     });
 
     // conflicts were automatically resolved


### PR DESCRIPTION
The autoFix strategy we're looking to implement depends on the branch which the backport is being created for, so it's important that we can access the targetBranch for the backport in our autofix handler.

(CODEOWNERS file should only be on master, if backport is to a non-master branch we should delete CODEOWNERS when it's conflicting)