### PR TITLE
By default append "(cherry picked from commit...)" to commit message. Disable with `--no-cherrypick-ref`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,25 +58,26 @@ Please note that dashes between the words are optional, for instance you can typ
 | Option              | Shorthand notation | Description                                            | Default        | Type            |
 | ------------------- | ------------------ | ------------------------------------------------------ | -------------- | --------------- |
 | --access-token      |                    | Github access token                                    |                | `string`        |
-| --all               | -a                 | Show commits from other than me                        | false          | `boolean`       |
-| --author            |                    | Filter commits by author                               | _Current user_ | `string`        |
+| --all               | -a                 | Show commits from other than yourself                  | false          | `boolean`       |
+| --author            |                    | Filter commits by Github username                      | _Current user_ | `string`        |
 | --assignee          | --assign           | Assign users to target pull request                    |                | `Array<string>` |
 | --auto-assign       |                    | Assign current user to target pull request             | false          | `boolean`       |
 | --branch            | -b                 | Target branch to backport to                           |                | `string`        |
 | --ci                |                    | Disable interactive prompts                            | false          | `boolean`       |
+| --cherrypick-ref    |                    | Append "(cherry picked from commit...)". [Git Docs][1] | false          | `boolean`       |
 | --dry-run           |                    | Perform backport without pushing to Github             | false          | `string`        |
-| --editor            |                    | Editor (eg. `code`) to open and solve conflicts        | nano           | `string`        |
-| --fork              |                    | Create backports in fork (true) or origin repo (false) | true           | `boolean`       |
+| --editor            |                    | Editor (eg. `code`) to open and resolve conflicts      | nano           | `string`        |
+| --fork              |                    | Create backports in fork repo                          | true           | `boolean`       |
 | --git-hostname      |                    | Hostname for Git                                       | github.com     | `string`        |
 | --mainline          |                    | Parent id of merge commit                              | 1              | `number`        |
 | --max-number        | --number, -n       | Number of commits to choose from                       | 10             | `number`        |
 | --multiple          |                    | Select multiple commits/branches                       | false          | `boolean`       |
 | --multiple-branches |                    | Backport to multiple branches                          | true           | `boolean`       |
 | --multiple-commits  |                    | Backport multiple commits                              | false          | `boolean`       |
-| --path              | -p                 | Only list commits touching files under a specific path |                | `string`        |
+| --path              | -p                 | Filter commits by path                                 |                | `string`        |
 | --pull-number       | --pr               | Pull request to backport                               |                | `number`        |
 | --pr-description    | --description      | Pull request description suffix                        |                | `string`        |
-| --pr-filter         |                    | Find PRs using [Github's search syntax][1]             |                | `string`        |
+| --pr-filter         |                    | Find PRs using [Github's search syntax][2]             |                | `string`        |
 | --pr-title          | --title            | Title of pull request                                  |                | `string`        |
 | --reset-author      |                    | Set yourself as commit author                          |                | `boolean`       |
 | --sha               |                    | Sha of commit to backport                              |                | `string`        |
@@ -120,4 +121,5 @@ This tools is for anybody who is working on a codebase where they have to mainta
 
 See [CONTRIBUTING.md](https://github.com/sqren/backport/blob/master/CONTRIBUTING.md)
 
-[1]: https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax
+[1]: https://git-scm.com/docs/git-cherry-pick#Documentation/git-cherry-pick.txt--x
+[2]: https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax

--- a/README.md
+++ b/README.md
@@ -55,40 +55,41 @@ See [configuration.md](https://github.com/sqren/backport/blob/master/docs/config
 
 Please note that dashes between the words are optional, for instance you can type `--targetBranch` or `--target-branch` both are valid options.
 
-| Option              | Shorthand notation | Description                                            | Default        | Type            |
-| ------------------- | ------------------ | ------------------------------------------------------ | -------------- | --------------- |
-| --access-token      |                    | Github access token                                    |                | `string`        |
-| --all               | -a                 | Show commits from other than yourself                  | false          | `boolean`       |
-| --author            |                    | Filter commits by Github username                      | _Current user_ | `string`        |
-| --assignee          | --assign           | Assign users to target pull request                    |                | `Array<string>` |
-| --auto-assign       |                    | Assign current user to target pull request             | false          | `boolean`       |
-| --branch            | -b                 | Target branch to backport to                           |                | `string`        |
-| --ci                |                    | Disable interactive prompts                            | false          | `boolean`       |
-| --cherrypick-ref    |                    | Append "(cherry picked from commit...)". [Git Docs][1] | false          | `boolean`       |
-| --dry-run           |                    | Perform backport without pushing to Github             | false          | `string`        |
-| --editor            |                    | Editor (eg. `code`) to open and resolve conflicts      | nano           | `string`        |
-| --fork              |                    | Create backports in fork repo                          | true           | `boolean`       |
-| --git-hostname      |                    | Hostname for Git                                       | github.com     | `string`        |
-| --mainline          |                    | Parent id of merge commit                              | 1              | `number`        |
-| --max-number        | --number, -n       | Number of commits to choose from                       | 10             | `number`        |
-| --multiple          |                    | Select multiple commits/branches                       | false          | `boolean`       |
-| --multiple-branches |                    | Backport to multiple branches                          | true           | `boolean`       |
-| --multiple-commits  |                    | Backport multiple commits                              | false          | `boolean`       |
-| --path              | -p                 | Filter commits by path                                 |                | `string`        |
-| --pull-number       | --pr               | Pull request to backport                               |                | `number`        |
-| --pr-description    | --description      | Pull request description suffix                        |                | `string`        |
-| --pr-filter         |                    | Find PRs using [Github's search syntax][2]             |                | `string`        |
-| --pr-title          | --title            | Title of pull request                                  |                | `string`        |
-| --reset-author      |                    | Set yourself as commit author                          |                | `boolean`       |
-| --sha               |                    | Sha of commit to backport                              |                | `string`        |
-| --source-branch     |                    | Specify a non-default branch to backport from          |                | `string`        |
-| --source-pr-label   |                    | Labels added to the source PR                          |                | `array<string>` |
-| --target-pr-label   | --label, -l        | Labels added to the target PR                          |                | `array<string>` |
-| --target-branch     | -b                 | Target branch(es) to backport to                       |                | `array<string>` |
-| --upstream          | --up               | Name of organization and repository                    |                | `string`        |
-| --username          |                    | Github username                                        |                | `string`        |
-| --help              |                    | Show help                                              |                |                 |
-| -v, --version       |                    | Show version number                                    |                |                 |
+| Option              | Shorthand notation | Description                                                   | Default        | Type      |
+| ------------------- | ------------------ | ------------------------------------------------------------- | -------------- | --------- |
+| --access-token      |                    | Github access token                                           |                | `string`  |
+| --all               | -a                 | Show commits from other than yourself                         | false          | `boolean` |
+| --author            |                    | Filter commits by Github username                             | _Current user_ | `string`  |
+| --assignee          | --assign           | Assign users to target pull request                           |                | `string`  |
+| --auto-assign       |                    | Assign current user to target pull request                    | false          | `boolean` |
+| --branch            | -b                 | Target branch to backport to                                  |                | `string`  |
+| --ci                |                    | Disable interactive prompts                                   | false          | `boolean` |
+| --dry-run           |                    | Perform backport without pushing to Github                    | false          | `string`  |
+| --editor            |                    | Editor (eg. `code`) to open and resolve conflicts             | nano           | `string`  |
+| --fork              |                    | Create backports in fork repo                                 | true           | `boolean` |
+| --git-hostname      |                    | Hostname for Git                                              | github.com     | `string`  |
+| --no-cherrypick-ref |                    | Do not append "(cherry picked from commit...)". [Git Docs][1] | false          | `boolean` |
+| --no-verify         |                    | Bypass the pre-commit and commit-msg hooks                    | false          | `boolean` |
+| --mainline          |                    | Parent id of merge commit                                     | 1              | `number`  |
+| --max-number        | --number, -n       | Number of commits to choose from                              | 10             | `number`  |
+| --multiple          |                    | Multi-select for commits and branches                         | false          | `boolean` |
+| --multiple-branches |                    | Multi-select for branches                                     | true           | `boolean` |
+| --multiple-commits  |                    | Multi-select for commits                                      | false          | `boolean` |
+| --path              | -p                 | Filter commits by path                                        |                | `string`  |
+| --pull-number       | --pr               | Backport pull request by number                               |                | `number`  |
+| --pr-description    | --description      | Pull request description suffix                               |                | `string`  |
+| --pr-filter         |                    | Find PRs using [Github's search syntax][2]                    |                | `string`  |
+| --pr-title          | --title            | Title of pull request                                         |                | `string`  |
+| --reset-author      |                    | Set yourself as commit author                                 |                | `boolean` |
+| --sha               |                    | Sha of commit to backport                                     |                | `string`  |
+| --source-branch     |                    | Specify a non-default branch to backport from                 |                | `string`  |
+| --source-pr-label   |                    | Labels added to the source PR                                 |                | `string`  |
+| --target-pr-label   | --label, -l        | Labels added to the target PR                                 |                | `string`  |
+| --target-branch     | -b                 | Target branch(es) to backport to                              |                | `string`  |
+| --upstream          | --up               | Name of organization and repository                           |                | `string`  |
+| --username          |                    | Github username                                               |                | `string`  |
+| --help              |                    | Show help                                                     |                |           |
+| -v, --version       |                    | Show version number                                           |                |           |
 
 The CLI options will override the [configuration options](https://github.com/sqren/backport/blob/master/docs/configuration.md).
 

--- a/src/options/ConfigOptions.ts
+++ b/src/options/ConfigOptions.ts
@@ -29,6 +29,7 @@ export type ConfigOptions = Partial<{
   autoMergeMethod: string;
   branchLabelMapping: Record<string, string>;
   ci: boolean;
+  cherrypickReference: boolean;
   commitPaths: string[];
   details: boolean;
   editor: string;

--- a/src/options/ConfigOptions.ts
+++ b/src/options/ConfigOptions.ts
@@ -29,7 +29,7 @@ export type ConfigOptions = Partial<{
   autoMergeMethod: string;
   branchLabelMapping: Record<string, string>;
   ci: boolean;
-  cherrypickReference: boolean;
+  cherrypickRef: boolean;
   commitPaths: string[];
   details: boolean;
   editor: string;

--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -63,6 +63,12 @@ export function getOptionsFromCliArgs(
       type: 'boolean',
     })
 
+    .option('cherrypickRef', {
+      description:
+        'Append commit message with "(cherry picked from commit...)"',
+      type: 'boolean',
+    })
+
     .option('details', {
       description: 'Show details about each commit',
       type: 'boolean',
@@ -293,6 +299,7 @@ export function getOptionsFromCliArgs(
     targetBranch,
     targetBranchChoice,
     targetPRLabel,
+    cherrypickRef,
 
     ...restOptions
   } = yargsInstance.parseSync();
@@ -303,6 +310,9 @@ export function getOptionsFromCliArgs(
     // `multiple` is a cli-only flag to override `multipleBranches` and `multipleCommits`
     multipleBranches: multiple ?? multipleBranches,
     multipleCommits: multiple ?? multipleCommits,
+
+    //rename to longer versions
+    cherrypickReference: cherrypickRef,
 
     // rename array types to plural
     assignees: assignee ?? [],

--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -64,8 +64,7 @@ export function getOptionsFromCliArgs(
     })
 
     .option('cherrypickRef', {
-      description:
-        'Append commit message with "(cherry picked from commit...)"',
+      description: 'Append commit message with "(cherry picked from commit...)',
       type: 'boolean',
     })
 
@@ -157,8 +156,14 @@ export function getOptionsFromCliArgs(
       conflicts: ['multiple'],
     })
 
+    .option('noCherrypickRef', {
+      description:
+        'Do not append commit message with "(cherry picked from commit...)"',
+      type: 'boolean',
+    })
+
     .option('noVerify', {
-      description: 'Bypasses the pre-commit and commit-msg hooks',
+      description: 'Bypass the pre-commit and commit-msg hooks',
       type: 'boolean',
     })
 
@@ -286,11 +291,15 @@ export function getOptionsFromCliArgs(
     $0,
     _,
     /* eslint-enable @typescript-eslint/no-unused-vars */
-    verify,
     multiple,
     multipleBranches,
     multipleCommits,
+
+    // negations
+    verify,
     noVerify,
+    cherrypickRef,
+    noCherrypickRef,
 
     // array types (should be renamed to plural form)
     assignee,
@@ -299,7 +308,6 @@ export function getOptionsFromCliArgs(
     targetBranch,
     targetBranchChoice,
     targetPRLabel,
-    cherrypickRef,
 
     ...restOptions
   } = yargsInstance.parseSync();
@@ -311,9 +319,6 @@ export function getOptionsFromCliArgs(
     multipleBranches: multiple ?? multipleBranches,
     multipleCommits: multiple ?? multipleCommits,
 
-    //rename to longer versions
-    cherrypickReference: cherrypickRef,
-
     // rename array types to plural
     assignees: assignee ?? [],
     commitPaths: path ?? [],
@@ -322,7 +327,8 @@ export function getOptionsFromCliArgs(
     targetBranches: targetBranch,
     targetPRLabels: targetPRLabel,
 
-    // `verify` is a cli-only flag to flip the default of `no-verify`
+    // negations (cli-only flags)
+    cherrypickRef: noCherrypickRef ? false : cherrypickRef,
     noVerify: verify ?? noVerify,
   });
 }

--- a/src/options/config/config.test.ts
+++ b/src/options/config/config.test.ts
@@ -16,7 +16,7 @@ describe('getOptionsFromConfigFiles', () => {
       autoMerge: false,
       autoMergeMethod: 'merge',
       ci: false,
-      cherrypickReference: true,
+      cherrypickRef: true,
       details: false,
       fork: true,
       gitHostname: 'github.com',

--- a/src/options/config/config.test.ts
+++ b/src/options/config/config.test.ts
@@ -16,6 +16,7 @@ describe('getOptionsFromConfigFiles', () => {
       autoMerge: false,
       autoMergeMethod: 'merge',
       ci: false,
+      cherrypickReference: true,
       details: false,
       fork: true,
       gitHostname: 'github.com',

--- a/src/options/config/config.ts
+++ b/src/options/config/config.ts
@@ -10,6 +10,7 @@ export const defaultConfigOptions = {
   autoMerge: false,
   autoMergeMethod: 'merge',
   ci: false,
+  cherrypickReference: true,
   details: false,
   fork: true,
   gitHostname: 'github.com',

--- a/src/options/config/config.ts
+++ b/src/options/config/config.ts
@@ -10,7 +10,7 @@ export const defaultConfigOptions = {
   autoMerge: false,
   autoMergeMethod: 'merge',
   ci: false,
-  cherrypickReference: true,
+  cherrypickRef: true,
   details: false,
   fork: true,
   gitHostname: 'github.com',

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -114,6 +114,7 @@ describe('getOptions', () => {
       autoMerge: false,
       autoMergeMethod: 'merge',
       ci: false,
+      cherrypickReference: true,
       details: false,
       fork: true,
       gitHostname: 'github.com',

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -114,7 +114,7 @@ describe('getOptions', () => {
       autoMerge: false,
       autoMergeMethod: 'merge',
       ci: false,
-      cherrypickReference: true,
+      cherrypickRef: true,
       details: false,
       fork: true,
       gitHostname: 'github.com',
@@ -141,6 +141,49 @@ describe('getOptions', () => {
       upstream: 'elastic/kibana',
       username: 'sqren',
       verbose: false,
+    });
+  });
+
+  describe('cherrypickRef', () => {
+    beforeEach(() => {
+      mockGetGithubConfigOptions({ defaultBranch: 'my-default-branch' });
+    });
+    const defaultArgs = [
+      // use localhost to avoid CORS issues with nock
+      '--github-api-base-url-v4',
+      'http://localhost/graphql',
+    ];
+
+    it('should default to true', async () => {
+      const { cherrypickRef } = await getOptions(defaultArgs);
+      expect(cherrypickRef).toBe(true);
+    });
+
+    it('should negate with `noCherrypickRef` cli arg', async () => {
+      const { cherrypickRef } = await getOptions([
+        ...defaultArgs,
+        '--no-cherrypick-ref',
+      ]);
+      expect(cherrypickRef).toBe(false);
+    });
+
+    it('should be settable via config file', async () => {
+      const { cherrypickRef } = await getOptions([...defaultArgs], {
+        cherrypickRef: false,
+      });
+
+      expect(cherrypickRef).toBe(false);
+    });
+
+    it('cli args overwrites config', async () => {
+      const { cherrypickRef } = await getOptions(
+        [...defaultArgs, '--cherrypick-ref'],
+        {
+          cherrypickRef: false,
+        }
+      );
+
+      expect(cherrypickRef).toBe(true);
     });
   });
 });

--- a/src/runWithOptions.test.ts
+++ b/src/runWithOptions.test.ts
@@ -266,7 +266,7 @@ describe('runWithOptions', () => {
           },
         ],
         Array [
-          "git cherry-pick 2e63475c483f7844b0f2833bc57fdee32095bacb",
+          "git cherry-pick -x 2e63475c483f7844b0f2833bc57fdee32095bacb",
           Object {
             "cwd": "/myHomeDir/.backport/repositories/elastic/kibana",
           },

--- a/src/runWithOptions.test.ts
+++ b/src/runWithOptions.test.ts
@@ -57,7 +57,7 @@ describe('runWithOptions', () => {
       autoMergeMethod: 'merge',
       branchLabelMapping: undefined,
       ci: false,
-      cherrypickReference: true,
+      cherrypickRef: true,
       commitPaths: [],
       details: false,
       editor: 'code',

--- a/src/runWithOptions.test.ts
+++ b/src/runWithOptions.test.ts
@@ -57,6 +57,7 @@ describe('runWithOptions', () => {
       autoMergeMethod: 'merge',
       branchLabelMapping: undefined,
       ci: false,
+      cherrypickReference: true,
       commitPaths: [],
       details: false,
       editor: 'code',

--- a/src/services/git.integration.test.ts
+++ b/src/services/git.integration.test.ts
@@ -167,7 +167,7 @@ describe('git.integration', () => {
 
     it('should cherrypick commit cleanly', async () => {
       const res = await cherrypick(
-        { cherrypickReference: false } as ValidConfigOptions,
+        { cherrypickRef: false } as ValidConfigOptions,
         secondSha
       );
       expect(res).toEqual({
@@ -183,7 +183,7 @@ describe('git.integration', () => {
 
     it('should cherrypick commit cleanly and append "(cherry picked from commit...)"', async () => {
       const res = await cherrypick(
-        { cherrypickReference: true } as ValidConfigOptions,
+        { cherrypickRef: true } as ValidConfigOptions,
         secondSha
       );
       expect(res).toEqual({

--- a/src/services/git.integration.test.ts
+++ b/src/services/git.integration.test.ts
@@ -166,7 +166,10 @@ describe('git.integration', () => {
     });
 
     it('should cherrypick commit cleanly', async () => {
-      const res = await cherrypick({} as ValidConfigOptions, secondSha);
+      const res = await cherrypick(
+        { cherrypickReference: false } as ValidConfigOptions,
+        secondSha
+      );
       expect(res).toEqual({
         conflictingFiles: [],
         needsResolving: false,
@@ -176,6 +179,24 @@ describe('git.integration', () => {
       const message = await getCurrentMessage(execOpts);
 
       expect(message).toEqual(`Update bar.md`);
+    });
+
+    it('should cherrypick commit cleanly and append "(cherry picked from commit...)"', async () => {
+      const res = await cherrypick(
+        { cherrypickReference: true } as ValidConfigOptions,
+        secondSha
+      );
+      expect(res).toEqual({
+        conflictingFiles: [],
+        needsResolving: false,
+        unstagedFiles: [],
+      });
+
+      const message = await getCurrentMessage(execOpts);
+
+      expect(message).toEqual(
+        `Update bar.md\n\n(cherry picked from commit ${secondSha})`
+      );
     });
 
     it('should cherrypick commit with conflicts', async () => {

--- a/src/services/git.ts
+++ b/src/services/git.ts
@@ -198,7 +198,7 @@ export async function cherrypick(
   const mainlinArg =
     options.mainline != undefined ? ` --mainline ${options.mainline}` : '';
 
-  const cherrypickRefArg = options.cherrypickReference ? ' -x' : '';
+  const cherrypickRefArg = options.cherrypickRef ? ' -x' : '';
   const cmd = `git cherry-pick${cherrypickRefArg}${mainlinArg} ${sha}`;
   try {
     await exec(cmd, { cwd: getRepoPath(options) });

--- a/src/services/git.ts
+++ b/src/services/git.ts
@@ -195,10 +195,11 @@ export async function cherrypick(
   unstagedFiles: string[];
   needsResolving: boolean;
 }> {
-  const mainline =
+  const mainlinArg =
     options.mainline != undefined ? ` --mainline ${options.mainline}` : '';
 
-  const cmd = `git cherry-pick${mainline} ${sha}`;
+  const cherrypickRefArg = options.cherrypickReference ? ' -x' : '';
+  const cmd = `git cherry-pick${cherrypickRefArg}${mainlinArg} ${sha}`;
   try {
     await exec(cmd, { cwd: getRepoPath(options) });
     return { conflictingFiles: [], unstagedFiles: [], needsResolving: false };


### PR DESCRIPTION
Closes https://github.com/sqren/backport/issues/243

 - `cherrypickRef` option will append "(cherry picked from commit...)" to commit message. 
 - `cherrypickRef` will default to to and can be disabled with `--no-cherrypick-ref`