### PR TITLE
`--all` should be respected

### DIFF
--- a/src/options/cliArgs.test.ts
+++ b/src/options/cliArgs.test.ts
@@ -21,8 +21,6 @@ describe('getOptionsFromCliArgs', () => {
       const argv = [
         '--access-token',
         'my access token',
-        '--author',
-        'sqren',
         '--repo-owner',
         'elastic',
         '--repo-name',
@@ -33,11 +31,6 @@ describe('getOptionsFromCliArgs', () => {
         accessToken: 'my access token',
         repoOwner: 'elastic',
         repoName: 'kibana',
-        author: 'sqren',
-        mainline: 1,
-        reviewers: [],
-        assignees: [],
-        commitPaths: [],
       });
     });
   });

--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -112,9 +112,10 @@ export function getOptionsFromCliArgs(
         'Parent id of merge commit. Defaults to 1 when supplied without arguments',
       type: 'number',
       coerce: (mainline) => {
-        // `--mainline` (default to 1 when no parent is given)
         if (mainline === undefined) {
-          return 1;
+          // return 1 if `--mainline` is given without a value
+          // return undefined if --mainline is not supplied at all
+          return argv.includes('--mainline') ? 1 : undefined;
         }
 
         // use specified mainline parent
@@ -343,9 +344,9 @@ export function getOptionsFromCliArgs(
     multipleCommits: multiple ?? multipleCommits,
 
     // rename array types to plural
-    assignees: assignee ?? [],
-    commitPaths: path ?? [],
-    reviewers: reviewer ?? [],
+    assignees: assignee,
+    commitPaths: path,
+    reviewers: reviewer,
     sourcePRLabels: sourcePRLabel,
     targetBranchChoices: targetBranchChoice,
     targetBranches: targetBranch,

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -3,12 +3,322 @@ import { GithubConfigOptionsResponse } from '../services/github/v4/getOptionsFro
 import * as logger from '../services/logger';
 import { mockConfigFiles } from '../test/mockConfigFiles';
 import { mockGqlRequest } from '../test/nockHelpers';
+import { ConfigFileOptions } from './ConfigOptions';
 import { getOptions } from './options';
 
 jest.unmock('../services/fs-promisified');
 
+const defaultConfigs = {
+  projectConfig: {
+    // use localhost to avoid CORS issues with nock
+    githubApiBaseUrlV4: 'http://localhost/graphql',
+    repoOwner: 'elastic',
+    repoName: 'kibana',
+    targetBranchChoices: ['7.9', '8.0'],
+  },
+  globalConfig: { accessToken: 'abc', editor: 'code' },
+};
+
+describe('getOptions', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    nock.cleanAll();
+  });
+
+  beforeEach(() => {
+    mockConfigFiles(defaultConfigs);
+  });
+
+  describe('should throw', () => {
+    beforeEach(() => {
+      mockGithubConfigOptions({});
+    });
+
+    it('when accessToken is missing', async () => {
+      mockConfigFiles({
+        projectConfig: defaultConfigs.projectConfig,
+        globalConfig: { accessToken: undefined },
+      });
+      await expect(() => getOptions([])).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
+              "Please update your config file: /Users/sqren/.backport/config.json.
+              It must contain a valid \\"accessToken\\".
+
+              Read more: https://github.com/sqren/backport/blob/main/docs/configuration.md#global-config-backportconfigjson"
+            `);
+    });
+
+    it('when `targetBranches`, `targetBranchChoices` and `branchLabelMapping` are all empty', async () => {
+      mockProjectConfig({
+        targetBranches: undefined,
+        targetBranchChoices: undefined,
+        branchLabelMapping: undefined,
+      });
+
+      await expect(() => getOptions([])).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
+              "Please specify a target branch: \\"--branch 6.1\\".
+
+              Read more: https://github.com/sqren/backport/blob/main/docs/configuration.md#project-config-backportrcjson"
+            `);
+    });
+
+    it('when repoName is missing', async () => {
+      mockProjectConfig({ repoName: '' });
+
+      await expect(() => getOptions([])).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
+              "Please specify a repo name: \\"--repo-name kibana\\".
+
+              Read more: https://github.com/sqren/backport/blob/main/docs/configuration.md#project-config-backportrcjson"
+            `);
+    });
+
+    it('when repoOwner is missing', async () => {
+      mockProjectConfig({ repoOwner: '' });
+
+      await expect(() => getOptions([])).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
+              "Please specify a repo owner: \\"--repo-owner elastic\\".
+
+              Read more: https://github.com/sqren/backport/blob/main/docs/configuration.md#project-config-backportrcjson"
+            `);
+    });
+  });
+
+  it('should ensure that "backport" branch does not exist', async () => {
+    mockGithubConfigOptions({ refName: 'backport' });
+    await expect(getOptions([])).rejects.toThrowError(
+      'You must delete the branch "backport" to continue. See https://github.com/sqren/backport/issues/155 for details'
+    );
+  });
+
+  it('should merge config options and module options', async () => {
+    mockGithubConfigOptions({});
+    const myFn = async () => true;
+
+    const options = await getOptions([], { autoFixConflicts: myFn });
+    expect(options.autoFixConflicts).toBe(myFn);
+  });
+
+  it('should call updateLogger', async () => {
+    mockGithubConfigOptions({});
+    await getOptions([]);
+
+    expect(logger.updateLogger).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return options', async () => {
+    mockGithubConfigOptions({
+      viewerLogin: 'john.diller',
+      defaultBranchRef: 'default-branch-from-github',
+      historicalMappings: [
+        {
+          committedDate: '2022-01-02T20:52:45.173Z',
+          branchLabelMapping: { foo: 'bar' },
+        },
+      ],
+    });
+    const options = await getOptions([]);
+
+    expect(options).toEqual({
+      accessToken: 'abc',
+      assignees: [],
+      autoAssign: false,
+      autoMerge: false,
+      autoMergeMethod: 'merge',
+      authenticatedUsername: 'john.diller',
+      branchLabelMapping: {
+        foo: 'bar',
+      },
+      cherrypickRef: true,
+      ci: false,
+      commitPaths: [],
+      details: false,
+      editor: 'code',
+      fork: true,
+      githubApiBaseUrlV4: 'http://localhost/graphql',
+      historicalBranchLabelMappings: [
+        {
+          branchLabelMapping: { foo: 'bar' },
+          committedDate: '2022-01-02T20:52:45.173Z',
+        },
+      ],
+      maxNumber: 10,
+      multipleBranches: true,
+      multipleCommits: false,
+      noVerify: true,
+      repoName: 'kibana',
+      repoOwner: 'elastic',
+      resetAuthor: false,
+      reviewers: [],
+      sourceBranch: 'default-branch-from-github',
+      sourcePRLabels: [],
+      targetBranchChoices: ['7.9', '8.0'],
+      targetBranches: [],
+      targetPRLabels: [],
+      author: 'john.diller',
+      verbose: false,
+    });
+  });
+
+  describe('sourceBranch', () => {
+    beforeEach(() => {
+      mockGithubConfigOptions({ defaultBranchRef: 'some-default-branch' });
+    });
+
+    it('uses the `defaultBranchRef` as default', async () => {
+      const options = await getOptions([]);
+      expect(options.sourceBranch).toBe('some-default-branch');
+    });
+
+    it('uses the sourceBranch given via cli instead of `defaultBranchRef`', async () => {
+      const options = await getOptions([
+        '--source-branch',
+        'cli-source-branch',
+      ]);
+      expect(options.sourceBranch).toBe('cli-source-branch');
+    });
+  });
+
+  describe('fork', () => {
+    beforeEach(() => {
+      mockGithubConfigOptions({});
+    });
+
+    it('is enabled by default', async () => {
+      const { fork } = await getOptions([]);
+      expect(fork).toBe(true);
+    });
+
+    it('can be disabled via `--no-fork` flag', async () => {
+      const { fork } = await getOptions(['--no-fork']);
+      expect(fork).toBe(false);
+    });
+
+    it('can be disabled via config file', async () => {
+      mockProjectConfig({ fork: false });
+      const { fork } = await getOptions([]);
+      expect(fork).toBe(false);
+    });
+  });
+
+  describe('reviewers', () => {
+    beforeEach(() => {
+      mockGithubConfigOptions({});
+    });
+
+    it('can be set via `--reviewer` flag', async () => {
+      const { reviewers } = await getOptions(['--reviewer', 'peter']);
+      expect(reviewers).toEqual(['peter']);
+    });
+
+    it('can be set via config file', async () => {
+      mockProjectConfig({ reviewers: ['john'] });
+      const { reviewers } = await getOptions([]);
+      expect(reviewers).toEqual(['john']);
+    });
+  });
+
+  describe('mainline', () => {
+    beforeEach(() => {
+      mockGithubConfigOptions({});
+    });
+
+    it('is not enabled by default', async () => {
+      const { mainline } = await getOptions([]);
+      expect(mainline).toBe(undefined);
+    });
+
+    it('can be set via `--mainline` flag', async () => {
+      const { mainline } = await getOptions(['--mainline']);
+      expect(mainline).toBe(1);
+    });
+
+    it('accepts numeric values', async () => {
+      const { mainline } = await getOptions(['--mainline', '2']);
+      expect(mainline).toBe(2);
+    });
+  });
+
+  describe('author', () => {
+    beforeEach(() => {
+      mockGithubConfigOptions({ viewerLogin: 'billy.bob' });
+    });
+
+    it('defaults to authenticated user', async () => {
+      const { author } = await getOptions([]);
+      expect(author).toBe('billy.bob');
+    });
+
+    it('can be overridden via `--author` flag', async () => {
+      const { author } = await getOptions(['--author', 'john.doe']);
+      expect(author).toBe('john.doe');
+    });
+
+    it('can be reset via `--all` flag', async () => {
+      const { author } = await getOptions(['--all']);
+      expect(author).toBe(null);
+    });
+
+    it('can be reset via config file (similar to `--all` flag)', async () => {
+      mockProjectConfig({ author: null });
+      const { author } = await getOptions([]);
+      expect(author).toBe(null);
+    });
+
+    it('can be overridden via config file', async () => {
+      mockProjectConfig({ author: 'jane.doe' });
+      const { author } = await getOptions([]);
+      expect(author).toBe('jane.doe');
+    });
+  });
+
+  describe('cherrypickRef', () => {
+    beforeEach(() => {
+      mockGithubConfigOptions({});
+    });
+
+    it('should default to true', async () => {
+      const { cherrypickRef } = await getOptions([]);
+      expect(cherrypickRef).toBe(true);
+    });
+
+    it('should negate with `noCherrypickRef` cli arg', async () => {
+      const { cherrypickRef } = await getOptions(['--no-cherrypick-ref']);
+      expect(cherrypickRef).toBe(false);
+    });
+
+    it('should be settable via config file', async () => {
+      mockProjectConfig({ cherrypickRef: false });
+      const { cherrypickRef } = await getOptions([]);
+      expect(cherrypickRef).toBe(false);
+    });
+
+    it('cli args overwrites config', async () => {
+      mockProjectConfig({ cherrypickRef: false });
+      const { cherrypickRef } = await getOptions(['--cherrypick-ref']);
+      expect(cherrypickRef).toBe(true);
+    });
+  });
+});
+
+function mockProjectConfig(projectConfig: ConfigFileOptions) {
+  return mockConfigFiles({
+    globalConfig: { accessToken: 'abc' },
+    projectConfig: {
+      // use localhost to avoid CORS issues with nock
+      githubApiBaseUrlV4: 'http://localhost/graphql',
+      repoOwner: 'elastic',
+      repoName: 'kibana',
+      targetBranchChoices: ['7.9', '8.0'],
+      ...projectConfig,
+    },
+  });
+}
+
 function mockGithubConfigOptions({
-  viewerLogin = 'sqren',
+  viewerLogin = 'DO_NOT_USE-sqren',
   defaultBranchRef = 'DO_NOT_USE-default-branch-name',
   refName,
   historicalMappings = [],
@@ -61,259 +371,3 @@ function mockGithubConfigOptions({
     },
   });
 }
-
-const defaultConfigs = {
-  projectConfig: {
-    // use localhost to avoid CORS issues with nock
-    githubApiBaseUrlV4: 'http://localhost/graphql',
-    repoOwner: 'elastic',
-    repoName: 'kibana',
-    targetBranchChoices: ['7.9', '8.0'],
-  },
-  globalConfig: { accessToken: 'abc', editor: 'code' },
-};
-
-describe('getOptions', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-    nock.cleanAll();
-  });
-
-  beforeEach(() => {
-    mockConfigFiles(defaultConfigs);
-  });
-
-  describe('should throw', () => {
-    beforeEach(() => {
-      mockGithubConfigOptions({});
-    });
-
-    it('when accessToken is missing', async () => {
-      mockConfigFiles({
-        projectConfig: defaultConfigs.projectConfig,
-        globalConfig: { accessToken: undefined },
-      });
-      await expect(() => getOptions([])).rejects
-        .toThrowErrorMatchingInlineSnapshot(`
-              "Please update your config file: /Users/sqren/.backport/config.json.
-              It must contain a valid \\"accessToken\\".
-
-              Read more: https://github.com/sqren/backport/blob/main/docs/configuration.md#global-config-backportconfigjson"
-            `);
-    });
-
-    it('when `targetBranches`, `targetBranchChoices` and `branchLabelMapping` are all empty', async () => {
-      mockConfigFiles({
-        projectConfig: {
-          ...defaultConfigs.projectConfig,
-          targetBranchChoices: undefined,
-          branchLabelMapping: undefined,
-        },
-        globalConfig: { accessToken: 'abc' },
-      });
-
-      await expect(() => getOptions([])).rejects
-        .toThrowErrorMatchingInlineSnapshot(`
-              "Please specify a target branch: \\"--branch 6.1\\". 
-
-               Read more: https://github.com/sqren/backport/blob/main/docs/configuration.md#project-config-backportrcjson"
-            `);
-    });
-
-    it('when repoName is missing', async () => {
-      mockConfigFiles({
-        projectConfig: {
-          ...defaultConfigs.projectConfig,
-          repoName: '',
-        },
-        globalConfig: { accessToken: 'abc' },
-      });
-
-      await expect(() => getOptions([])).rejects
-        .toThrowErrorMatchingInlineSnapshot(`
-              "Please specify a repo name: \\"--repo-name kibana\\". 
-
-              Read more: https://github.com/sqren/backport/blob/main/docs/configuration.md#project-config-backportrcjson"
-            `);
-    });
-
-    it('when repoOwner is missing', async () => {
-      mockConfigFiles({
-        projectConfig: {
-          ...defaultConfigs.projectConfig,
-          repoOwner: '',
-        },
-        globalConfig: { accessToken: 'abc' },
-      });
-
-      await expect(() => getOptions([])).rejects
-        .toThrowErrorMatchingInlineSnapshot(`
-              "Please specify a repo owner: \\"--repo-owner elastic\\". 
-
-              Read more: https://github.com/sqren/backport/blob/main/docs/configuration.md#project-config-backportrcjson"
-            `);
-    });
-  });
-
-  describe('sourceBranch', () => {
-    beforeEach(() => {
-      mockGithubConfigOptions({ defaultBranchRef: 'some-default-branch' });
-    });
-
-    it('uses the `defaultBranchRef` as default', async () => {
-      const options = await getOptions([]);
-      expect(options.sourceBranch).toBe('some-default-branch');
-    });
-
-    it('uses the sourceBranch given via cli instead of `defaultBranchRef`', async () => {
-      const options = await getOptions([
-        '--source-branch',
-        'cli-source-branch',
-      ]);
-      expect(options.sourceBranch).toBe('cli-source-branch');
-    });
-  });
-
-  it('should ensure that "backport" branch does not exist', async () => {
-    mockGithubConfigOptions({
-      refName: 'backport',
-    });
-
-    await expect(getOptions([])).rejects.toThrowError(
-      'You must delete the branch "backport" to continue. See https://github.com/sqren/backport/issues/155 for details'
-    );
-  });
-
-  it('should merge config options and module options', async () => {
-    mockGithubConfigOptions({});
-    const myFn = async () => true;
-
-    const options = await getOptions([], { autoFixConflicts: myFn });
-    expect(options.autoFixConflicts).toBe(myFn);
-  });
-
-  it('should call updateLogger', async () => {
-    mockGithubConfigOptions({});
-    await getOptions([]);
-
-    expect(logger.updateLogger).toHaveBeenCalledTimes(1);
-  });
-
-  it('should return options', async () => {
-    mockGithubConfigOptions({
-      defaultBranchRef: 'default-branch-from-github',
-      historicalMappings: [
-        {
-          committedDate: '2022-01-02T20:52:45.173Z',
-          branchLabelMapping: { foo: 'bar' },
-        },
-      ],
-    });
-    const options = await getOptions([]);
-
-    expect(options).toEqual({
-      accessToken: 'abc',
-      assignees: [],
-      autoAssign: false,
-      autoMerge: false,
-      autoMergeMethod: 'merge',
-      authenticatedUsername: 'sqren',
-      branchLabelMapping: {
-        foo: 'bar',
-      },
-      cherrypickRef: true,
-      ci: false,
-      commitPaths: [],
-      details: false,
-      editor: 'code',
-      fork: true,
-      githubApiBaseUrlV4: 'http://localhost/graphql',
-      historicalBranchLabelMappings: [
-        {
-          branchLabelMapping: { foo: 'bar' },
-          committedDate: '2022-01-02T20:52:45.173Z',
-        },
-      ],
-      mainline: 1,
-      maxNumber: 10,
-      multipleBranches: true,
-      multipleCommits: false,
-      noVerify: true,
-      repoName: 'kibana',
-      repoOwner: 'elastic',
-      resetAuthor: false,
-      reviewers: [],
-      sourceBranch: 'default-branch-from-github',
-      sourcePRLabels: [],
-      targetBranchChoices: ['7.9', '8.0'],
-      targetBranches: [],
-      targetPRLabels: [],
-      author: 'sqren',
-      verbose: false,
-    });
-  });
-
-  describe('author', () => {
-    beforeEach(() => {
-      mockGithubConfigOptions({ viewerLogin: 'billy.bob' });
-    });
-
-    it('defaults to authenticated user', async () => {
-      const { author } = await getOptions([]);
-      expect(author).toBe('billy.bob');
-    });
-
-    it('can be overridden via cli args', async () => {
-      const { author } = await getOptions(['--author', 'john.doe']);
-      expect(author).toBe('john.doe');
-    });
-
-    it('can be overridden via config file', async () => {
-      mockConfigFiles({
-        globalConfig: { accessToken: 'abc' },
-        projectConfig: {
-          author: 'jane.doe',
-          githubApiBaseUrlV4: 'http://localhost/graphql',
-          targetBranchChoices: ['7.9', '8.0'],
-          repoName: 'foo',
-          repoOwner: 'bar',
-        },
-      });
-
-      const { author } = await getOptions([]);
-      expect(author).toBe('jane.doe');
-    });
-  });
-
-  describe('cherrypickRef', () => {
-    beforeEach(() => {
-      mockGithubConfigOptions({});
-    });
-
-    it('should default to true', async () => {
-      const { cherrypickRef } = await getOptions([]);
-      expect(cherrypickRef).toBe(true);
-    });
-
-    it('should negate with `noCherrypickRef` cli arg', async () => {
-      const { cherrypickRef } = await getOptions(['--no-cherrypick-ref']);
-      expect(cherrypickRef).toBe(false);
-    });
-
-    it('should be settable via config file', async () => {
-      const { cherrypickRef } = await getOptions([], {
-        cherrypickRef: false,
-      });
-
-      expect(cherrypickRef).toBe(false);
-    });
-
-    it('cli args overwrites config', async () => {
-      const { cherrypickRef } = await getOptions(['--cherrypick-ref'], {
-        cherrypickRef: false,
-      });
-
-      expect(cherrypickRef).toBe(true);
-    });
-  });
-});

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -27,6 +27,7 @@ export const defaultConfigOptions = {
   autoMergeMethod: 'merge',
   cherrypickRef: true,
   ci: false,
+  commitPaths: [] as Array<string>,
   details: false,
   fork: true,
   maxNumber: 10,
@@ -34,6 +35,7 @@ export const defaultConfigOptions = {
   multipleCommits: false,
   noVerify: true,
   resetAuthor: false,
+  reviewers: [] as Array<string>,
   sourcePRLabels: [] as string[],
   targetBranchChoices: [] as TargetBranchChoiceOrString[],
   targetBranches: [] as string[],
@@ -130,7 +132,7 @@ function requireAccessToken(combinedOptions: CombinedOptions): string {
 function requireRepoName(combinedOptions: CombinedOptions): string {
   if (!combinedOptions.repoName) {
     throw new HandledError(
-      `Please specify a repo name: "--repo-name kibana". \n\nRead more: ${PROJECT_CONFIG_DOCS_LINK}`
+      `Please specify a repo name: "--repo-name kibana".\n\nRead more: ${PROJECT_CONFIG_DOCS_LINK}`
     );
   }
   return combinedOptions.repoName;
@@ -139,7 +141,7 @@ function requireRepoName(combinedOptions: CombinedOptions): string {
 function requireRepoOwner(combinedOptions: CombinedOptions): string {
   if (!combinedOptions.repoOwner) {
     throw new HandledError(
-      `Please specify a repo owner: "--repo-owner elastic". \n\nRead more: ${PROJECT_CONFIG_DOCS_LINK}`
+      `Please specify a repo owner: "--repo-owner elastic".\n\nRead more: ${PROJECT_CONFIG_DOCS_LINK}`
     );
   }
   return combinedOptions.repoOwner;
@@ -158,7 +160,7 @@ function requireTargetBranch(config: {
     isEmpty(config.branchLabelMapping)
   ) {
     throw new HandledError(
-      `Please specify a target branch: "--branch 6.1". \n\n Read more: ${PROJECT_CONFIG_DOCS_LINK}`
+      `Please specify a target branch: "--branch 6.1".\n\nRead more: ${PROJECT_CONFIG_DOCS_LINK}`
     );
   }
 }

--- a/src/test/inquirer.private.test.ts
+++ b/src/test/inquirer.private.test.ts
@@ -40,7 +40,7 @@ describe('inquirer cli', () => {
     ]);
     expect(res).toMatchInlineSnapshot(`
       "Please specify a target branch: \\"--branch 6.1\\".
-       Read more: https://github.com/sqren/backport/blob/main/docs/configuration.md#project-config-backportrcjson"
+      Read more: https://github.com/sqren/backport/blob/main/docs/configuration.md#project-config-backportrcjson"
     `);
   });
 
@@ -52,20 +52,11 @@ describe('inquirer cli', () => {
       '--accessToken',
       devAccessToken,
     ]);
-    expect(res).toMatchInlineSnapshot(`
-      "? Select commit (Use arrow keys)
-      ❯ 1. v6.0.0
-        2. Bump dependencies
-        3. Add support for historical branch label mappings (#282)
-        4. Add status comment (#281)
-        5. Add \`--reviewer\` option (#280)
-        6. By default append \\"(cherry picked from commit...)\\" to commit message. Disab
-      le with \`--no-cherrypick-ref\` (#279)
-        7. Improve git unit tests (#278)
-        8. Add tests for \`getCommitsWithoutBackports\`
-        9. Add Details View and \`--details\` flag (#277)
-        10.Feature: Show hint about missing backports (#276)"
-    `);
+
+    const lineCount = res.split('\n').length;
+    expect(lineCount).toBe(12);
+
+    expect(res.includes('Select commit (Use arrow keys)')).toBe(true);
   });
 
   it('should return error when access token is invalid', async () => {

--- a/src/utils/excludeUndefined.test.ts
+++ b/src/utils/excludeUndefined.test.ts
@@ -8,10 +8,10 @@ describe('excludeUndefined', () => {
         bar: undefined,
         baz: null,
       })
-    ).toEqual({ foo: 'foo' });
+    ).toEqual({ foo: 'foo', baz: null });
   });
 
-  it('has the correct types', () => {
+  it('has the correct types after merging', () => {
     const obj = excludeUndefined({
       foo: 'foo',
       bar: undefined,
@@ -27,6 +27,6 @@ describe('excludeUndefined', () => {
       ...obj,
     };
 
-    expect(res).toEqual({ bar: 'bar', foo: 'foo' });
+    expect(res).toEqual({ bar: 'bar', foo: 'foo', baz: null });
   });
 });

--- a/src/utils/excludeUndefined.ts
+++ b/src/utils/excludeUndefined.ts
@@ -16,6 +16,6 @@ export function excludeUndefined<T extends Record<string, any>>(
   obj: T
 ): ExcludeUndefined<T> {
   return Object.fromEntries(
-    Object.entries(obj).filter(([, v]) => v != null)
+    Object.entries(obj).filter(([, v]) => v !== undefined)
   ) as ExcludeUndefined<T>;
 }


### PR DESCRIPTION
Regression from #283 

 - The `--all` flag was mistakenly ignored. This fixes the bug and adds missing test coverage
 - This also removes `mainline` argument by default (I don't know how it ended up being applied by default).