### PR TITLE
Add `--dir` flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 /dist
 /yarn-error.log
 .DS_Store
-/src/test/integration/mock-environment
+/src/test/tmp-mock-environments
 /src/test/private/accessToken.txt
 /src/services/git-test-temp

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,16 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Start backport",
+      "name": "Run file",
+      "program": "${file}",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "console": "integratedTerminal"
+    },
+
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Start backport (CLI)",
       "program": "${workspaceRoot}/src/entrypoint.cli.ts",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
       "args": [

--- a/README.md
+++ b/README.md
@@ -67,42 +67,44 @@ See [configuration.md](https://github.com/sqren/backport/blob/master/docs/config
 
 ### CLI options
 
-| Option              | Shorthand notation | Description                                                   | Default        |
-| ------------------- | ------------------ | ------------------------------------------------------------- | -------------- |
-| --access-token      |                    | Github access token                                           |                |
-| --all               | -a                 | Show commits from any author                                  | false          |
-| --assignee          | --assign           | Assign users to the target PR                                 |                |
-| --author            |                    | Filter commits by Github username. Opposite of `--all`        | _Current user_ |
-| --auto-assign       |                    | Assign current user to the target PR                          | false          |
-| --branch            | -b                 | Target branch to backport to                                  |                |
-| --ci                |                    | Disable interactive prompts                                   | false          |
-| --dry-run           |                    | Perform backport without pushing to Github                    | false          |
-| --editor            |                    | Editor (eg. `code`) to open and resolve conflicts             | nano           |
-| --fork              |                    | Create backports in fork repo                                 | true           |
-| --git-hostname      |                    | Hostname for Git                                              | github.com     |
-| --mainline          |                    | Parent id of merge commit                                     | 1              |
-| --max-number        | --number, -n       | Number of commits to choose from                              | 10             |
-| --multiple          |                    | Multi-select for commits and branches                         | false          |
-| --multiple-branches |                    | Multi-select for branches                                     | true           |
-| --multiple-commits  |                    | Multi-select for commits                                      | false          |
-| --no-cherrypick-ref |                    | Do not append "(cherry picked from commit...)". [Git Docs][1] | false          |
-| --no-verify         |                    | Bypass the pre-commit and commit-msg hooks                    | false          |
-| --path              | -p                 | Filter commits by path                                        |                |
-| --pr-description    | --description      | Pull request description suffix                               |                |
-| --pr-filter         |                    | Find PRs using [Github's search syntax][2]                    |                |
-| --pr-title          | --title            | Title of pull request                                         |                |
-| --pull-number       | --pr               | Backport pull request by number                               |                |
-| --repo-name         |                    | Name of repository                                            |                |
-| --repo-owner        |                    | Owner of repository                                           |                |
-| --reset-author      |                    | Set yourself as commit author                                 |                |
-| --reviewer          |                    | Add reviewer to the target PR                                 |                |
-| --sha               |                    | Sha of commit to backport                                     |                |
-| --source-branch     |                    | Specify a non-default branch to backport from                 |                |
-| --source-pr-label   |                    | Labels added to the source PR                                 |                |
-| --target-branch     | -b                 | Target branch(es) to backport to                              |                |
-| --target-pr-label   | --label, -l        | Labels added to the target PR                                 |                |
-| --help              |                    | Show help                                                     |                |
-| -v, --version       |                    | Show version number                                           |                |
+| Option              | Shorthand notation | Description                                                                | Default                   |
+| ------------------- | ------------------ | -------------------------------------------------------------------------- | ------------------------- |
+| --access-token      |                    | Github access token                                                        |                           |
+| --all               | -a                 | Show commits from any author                                               | false                     |
+| --assignee          | --assign           | Assign users to the target PR                                              |                           |
+| --author            |                    | Filter commits by Github username. Opposite of `--all`                     | _Current user_            |
+| --auto-assign       |                    | Assign current user to the target PR                                       | false                     |
+| --branch            | -b                 | Target branch to backport to                                               |                           |
+| --ci                |                    | Disable interactive prompts                                                | false                     |
+| --dir               |                    | Clone repository into custom directory                                     | ~/.backport/repositories/ |
+| --dry-run           |                    | Perform backport without pushing to Github                                 | false                     |
+| --editor            |                    | Editor (eg. `code`) to open and resolve conflicts                          | nano                      |
+| --fork              |                    | Create backports in fork repo                                              | true                      |
+| --git-hostname      |                    | Hostname for Git                                                           | github.com                |
+| --mainline          |                    | Parent id of merge commit                                                  | 1                         |
+| --max-number        | --number, -n       | Number of commits to choose from                                           | 10                        |
+| --multiple          |                    | Multi-select for commits and branches                                      | false                     |
+| --multiple-branches |                    | Multi-select for branches                                                  | true                      |
+| --multiple-commits  |                    | Multi-select for commits                                                   | false                     |
+| --no-cherrypick-ref |                    | Do not append "(cherry picked from commit...)". [Git Docs][1]              | false                     |
+| --no-status-comment |                    | Do not publish a status comment to Github with the results of the backport | false                     |
+| --no-verify         |                    | Bypass the pre-commit and commit-msg hooks                                 | false                     |
+| --path              | -p                 | Filter commits by path                                                     |                           |
+| --pr-description    | --description      | Pull request description suffix                                            |                           |
+| --pr-filter         |                    | Find PRs using [Github's search syntax][2]                                 |                           |
+| --pr-title          | --title            | Title of pull request                                                      |                           |
+| --pull-number       | --pr               | Backport pull request by number                                            |                           |
+| --repo-name         |                    | Name of repository                                                         |                           |
+| --repo-owner        |                    | Owner of repository                                                        |                           |
+| --reset-author      |                    | Set yourself as commit author                                              |                           |
+| --reviewer          |                    | Add reviewer to the target PR                                              |                           |
+| --sha               |                    | Sha of commit to backport                                                  |                           |
+| --source-branch     |                    | Specify a non-default branch to backport from                              |                           |
+| --source-pr-label   |                    | Labels added to the source PR                                              |                           |
+| --target-branch     | -b                 | Target branch(es) to backport to                                           |                           |
+| --target-pr-label   | --label, -l        | Labels added to the target PR                                              |                           |
+| --help              |                    | Show help                                                                  |                           |
+| -v, --version       |                    | Show version number                                                        |                           |
 
 The CLI options will override the [configuration options](https://github.com/sqren/backport/blob/master/docs/configuration.md).
 
@@ -238,7 +240,7 @@ This tools is for anybody who is working on a codebase where they have to mainta
 - ability to see which commits have been backported and to which branches
 - ability to customize the title, description and labels of the created backport PRs
 - all git operations are handled in a separate directory to not interfere with unstaged files
-- Conflicts are handled gracefully, and hints are provided to help the user understand the source of the conflict 
+- Conflicts are handled gracefully, and hints are provided to help the user understand the source of the conflict
 - backport a commit by specifying a PR: `backport --pr 1337`
 - list and backport commits by a particular user: `backport --author john`
 - list and backport commits by a particular path: `backport --path src/plugins/chatbot`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -215,6 +215,22 @@ Config:
 
 _Note: backslashes must be escaped._
 
+#### `dir`
+
+Clone repository into custom directory
+
+Default: `~/.backport/repositories/`
+
+CLI: `--dir=my/custom/tmp/repo/location`
+
+Config:
+
+```json
+{
+  "dir": "/my/custom/tmp/repo/location"
+}
+```
+
 #### `fork`
 
 `true`: Create backport branch in users own fork
@@ -387,6 +403,20 @@ Config:
 ```json
 {
   "prFilter": "label: \"Backport Needed\""
+}
+```
+
+#### `publishStatusComment`
+
+Whether to publish a status comment to Github with the results of the backport or not
+
+Default: `true`
+
+Config:
+
+```json
+{
+  "publishStatusComment": false
 }
 ```
 

--- a/src/entrypoint.module.ts
+++ b/src/entrypoint.module.ts
@@ -14,7 +14,8 @@ initLogger();
 export { BackportResponse } from './main';
 export { ConfigFileOptions } from './options/ConfigOptions';
 export { Commit } from './services/sourceCommit/parseSourceCommit';
-export { fetchProjectConfig } from './services/github/v4/fetchProjectConfig';
+export { fetchRemoteProjectConfig as getRemoteProjectConfig } from './services/github/v4/fetchRemoteProjectConfig';
+export { getGlobalConfig as getLocalGlobalConfig } from './options/config/globalConfig';
 
 export function backportRun(
   options: ConfigFileOptions,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import ora from 'ora';
 import { ConfigFileOptions } from './options/ConfigOptions';
 import { getOptions, ValidConfigOptions } from './options/options';
 import { runSequentially, Result } from './runSequentially';
@@ -27,11 +28,14 @@ export async function main(
   argv: string[],
   optionsFromModule?: ConfigFileOptions
 ): Promise<BackportResponse> {
+  const spinner = ora().start('Initializing...');
+
   let options: ValidConfigOptions | null = null;
   let commits: Commit[] = [];
 
   try {
     options = await getOptions(argv, optionsFromModule);
+    spinner.stop();
     commits = await getCommits(options);
     const targetBranches = await getTargetBranches(options, commits);
     const results = await runSequentially({ options, commits, targetBranches });
@@ -48,6 +52,7 @@ export async function main(
 
     return backportResponse;
   } catch (e) {
+    spinner.stop();
     const backportResponse: BackportResponse = {
       status: 'failure',
       commits,

--- a/src/options/ConfigOptions.ts
+++ b/src/options/ConfigOptions.ts
@@ -30,6 +30,7 @@ type Options = Partial<{
   cherrypickRef: boolean;
   ci: boolean;
   commitPaths: string[];
+  dir: string;
   details: boolean;
   editor: string;
   fork: boolean;
@@ -44,6 +45,7 @@ type Options = Partial<{
   prDescription: string;
   prFilter: string;
   prTitle: string;
+  publishStatusComment: boolean;
   pullNumber: number;
   repoName: string;
   repoOwner: string;

--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -178,6 +178,11 @@ export function getOptionsFromCliArgs(
       conflicts: ['cherrypickRef'],
     })
 
+    .option('noStatusComment', {
+      description: "Don't publish status comment to Github",
+      type: 'boolean',
+    })
+
     .option('noVerify', {
       description: 'Bypass the pre-commit and commit-msg hooks',
       type: 'boolean',
@@ -336,10 +341,11 @@ export function getOptionsFromCliArgs(
     until,
 
     // negations
-    verify,
-    noVerify,
     noCherrypickRef,
     noFork,
+    noStatusComment,
+    noVerify,
+    verify,
 
     // array types (should be renamed to plural form)
     assignee,
@@ -378,5 +384,6 @@ export function getOptionsFromCliArgs(
     cherrypickRef: noCherrypickRef === true ? false : restOptions.cherrypickRef,
     fork: noFork === true ? false : restOptions.fork,
     noVerify: verify ?? noVerify,
+    publishStatusComment: noStatusComment === true ? false : undefined,
   });
 }

--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -76,6 +76,11 @@ export function getOptionsFromCliArgs(
       type: 'string',
     })
 
+    .option('dir', {
+      description: 'Location where the temporary repository will be stored',
+      type: 'string',
+    })
+
     .option('details', {
       description: 'Show details about each commit',
       type: 'boolean',

--- a/src/options/config/config.test.ts
+++ b/src/options/config/config.test.ts
@@ -10,7 +10,7 @@ describe('getOptionsFromConfigFiles', () => {
       projectConfig: { repoName: 'kibana', repoOwner: 'elastic' },
     });
 
-    res = await getOptionsFromConfigFiles();
+    res = await getOptionsFromConfigFiles({ ci: false });
   });
 
   it('should return values from config files', () => {

--- a/src/options/config/config.ts
+++ b/src/options/config/config.ts
@@ -12,7 +12,7 @@ export async function getOptionsFromConfigFiles(
   const [gitConfig, projectConfig, globalConfig] = await Promise.all([
     getOptionsFromGit(),
     getProjectConfig(),
-    getGlobalConfig(optionsFromModule?.ci),
+    optionsFromModule?.ci ? undefined : getGlobalConfig(),
   ]);
 
   return {

--- a/src/options/config/config.ts
+++ b/src/options/config/config.ts
@@ -6,13 +6,17 @@ import { getProjectConfig } from './projectConfig';
 export type OptionsFromConfigFiles = Awaited<
   ReturnType<typeof getOptionsFromConfigFiles>
 >;
-export async function getOptionsFromConfigFiles(
-  optionsFromModule?: ConfigFileOptions
-) {
+export async function getOptionsFromConfigFiles({
+  optionsFromModule,
+  ci,
+}: {
+  optionsFromModule?: ConfigFileOptions;
+  ci: boolean;
+}) {
   const [gitConfig, projectConfig, globalConfig] = await Promise.all([
     getOptionsFromGit(),
     getProjectConfig(),
-    optionsFromModule?.ci ? undefined : getGlobalConfig(),
+    ci ? undefined : getGlobalConfig(),
   ]);
 
   return {

--- a/src/options/config/globalConfig.test.ts
+++ b/src/options/config/globalConfig.test.ts
@@ -31,8 +31,8 @@ describe('config', () => {
       );
     });
 
-    it("should create config folders if it they don't exist", () => {
-      expect(makeDir).toHaveBeenCalledWith('/myHomeDir/.backport/repositories');
+    it("should create .backport folder if it doesn't exist", () => {
+      expect(makeDir).toHaveBeenCalledWith('/myHomeDir/.backport');
     });
 
     it('should load config', () => {

--- a/src/options/config/globalConfig.ts
+++ b/src/options/config/globalConfig.ts
@@ -1,27 +1,21 @@
 import makeDir from 'make-dir';
-import { getGlobalConfigPath, getReposPath } from '../../services/env';
+import { getBackportDirPath, getGlobalConfigPath } from '../../services/env';
 import { chmod, writeFile } from '../../services/fs-promisified';
 import { ConfigFileOptions } from '../ConfigOptions';
 import { readConfigFile } from './readConfigFile';
 
-export async function getGlobalConfig(
-  ci?: boolean
-): Promise<ConfigFileOptions | undefined> {
-  // don't attempt to fetch global config in ci environment
-  if (ci) {
-    return;
-  }
-
+export async function getGlobalConfig(): Promise<ConfigFileOptions> {
   await createGlobalConfigAndFolderIfNotExist();
   const globalConfigPath = getGlobalConfigPath();
   return readConfigFile(globalConfigPath);
 }
 
 export async function createGlobalConfigAndFolderIfNotExist() {
-  const reposPath = getReposPath();
+  // create .backport folder
+  await makeDir(getBackportDirPath());
+
   const globalConfigPath = getGlobalConfigPath();
   const configTemplate = getConfigTemplate();
-  await makeDir(reposPath);
   const didCreate = await createGlobalConfigIfNotExist(
     globalConfigPath,
     configTemplate

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -124,8 +124,9 @@ describe('getOptions', () => {
     expect(options).toEqual({
       accessToken: 'abc',
       assignees: [],
-      autoAssign: false,
       authenticatedUsername: 'john.diller',
+      author: 'john.diller',
+      autoAssign: false,
       autoMerge: false,
       autoMergeMethod: 'merge',
       backportBinary: 'backport',
@@ -151,6 +152,7 @@ describe('getOptions', () => {
       multipleBranches: true,
       multipleCommits: false,
       noVerify: true,
+      publishStatusComment: true,
       repoName: 'kibana',
       repoOwner: 'elastic',
       resetAuthor: false,
@@ -160,7 +162,6 @@ describe('getOptions', () => {
       targetBranchChoices: ['7.9', '8.0'],
       targetBranches: [],
       targetPRLabels: [],
-      author: 'john.diller',
       verbose: false,
     });
   });

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -50,11 +50,14 @@ export async function getOptions(
   argv: string[],
   optionsFromModule?: ConfigFileOptions
 ) {
-  const optionsFromConfigFiles = await getOptionsFromConfigFiles(
-    optionsFromModule
-  );
-
   const optionsFromCliArgs = getOptionsFromCliArgs(argv);
+  const ci =
+    optionsFromCliArgs.ci ?? optionsFromModule?.ci ?? defaultConfigOptions.ci;
+
+  const optionsFromConfigFiles = await getOptionsFromConfigFiles({
+    optionsFromModule,
+    ci,
+  });
 
   // combined options from cli and config files
   const combined = getCombinedOptions({

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -37,6 +37,7 @@ export const defaultConfigOptions = {
   multipleBranches: true,
   multipleCommits: false,
   noVerify: true,
+  publishStatusComment: true,
   resetAuthor: false,
   reviewers: [] as Array<string>,
   sourcePRLabels: [] as string[],

--- a/src/runSequentially.test.ts
+++ b/src/runSequentially.test.ts
@@ -185,9 +185,8 @@ describe('runSequentially', () => {
     expect(rpcExecOriginalMock.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
-          "git clone https://x-access-token:myAccessToken@github.com/elastic/kibana.git --progress",
+          "git clone https://x-access-token:myAccessToken@github.com/elastic/kibana.git /myHomeDir/.backport/repositories/elastic/kibana --progress",
           Object {
-            "cwd": "/myHomeDir/.backport/repositories/elastic",
             "maxBuffer": 104857600,
           },
           [Function],

--- a/src/runSequentially.test.ts
+++ b/src/runSequentially.test.ts
@@ -70,6 +70,7 @@ describe('runSequentially', () => {
       prDescription: 'myPrDescription',
       prFilter: undefined,
       prTitle: 'myPrTitle {targetBranch} {commitMessages}',
+      publishStatusComment: true,
       pullNumber: undefined,
       repoName: 'kibana',
       repoOwner: 'elastic',

--- a/src/services/env.test.ts
+++ b/src/services/env.test.ts
@@ -1,11 +1,6 @@
 import os from 'os';
 import { ValidConfigOptions } from '../options/options';
-import {
-  getGlobalConfigPath,
-  getRepoOwnerPath,
-  getRepoPath,
-  getReposPath,
-} from '../services/env';
+import { getGlobalConfigPath, getRepoPath } from '../services/env';
 
 describe('env', () => {
   beforeEach(() => {
@@ -14,16 +9,6 @@ describe('env', () => {
 
   test('getGlobalConfigPath', () => {
     expect(getGlobalConfigPath()).toBe('/myHomeDir/.backport/config.json');
-  });
-
-  test('getReposPath', () => {
-    expect(getReposPath()).toBe('/myHomeDir/.backport/repositories');
-  });
-
-  test('getRepoOwnerPath', () => {
-    expect(
-      getRepoOwnerPath({ repoOwner: 'elastic' } as ValidConfigOptions)
-    ).toBe('/myHomeDir/.backport/repositories/elastic');
   });
 
   test('getRepoPath', () => {

--- a/src/services/env.ts
+++ b/src/services/env.ts
@@ -2,6 +2,10 @@ import { homedir } from 'os';
 import path from 'path';
 import { ValidConfigOptions } from '../options/options';
 
+export function getBackportDirPath() {
+  return path.join(homedir(), '.backport');
+}
+
 export function getLogfilePath() {
   return path.join(homedir(), '.backport', 'backport.log');
 }
@@ -10,14 +14,10 @@ export function getGlobalConfigPath() {
   return path.join(homedir(), '.backport', 'config.json');
 }
 
-export function getReposPath() {
-  return path.join(homedir(), '.backport', 'repositories');
-}
+export function getRepoPath({ repoOwner, repoName, dir }: ValidConfigOptions) {
+  if (dir) {
+    return dir;
+  }
 
-export function getRepoOwnerPath({ repoOwner }: ValidConfigOptions) {
-  return path.join(homedir(), '.backport', 'repositories', repoOwner);
-}
-
-export function getRepoPath({ repoOwner, repoName }: ValidConfigOptions) {
   return path.join(homedir(), '.backport', 'repositories', repoOwner, repoName);
 }

--- a/src/services/git.ts
+++ b/src/services/git.ts
@@ -5,7 +5,7 @@ import ora from 'ora';
 import { ValidConfigOptions } from '../options/options';
 import { HandledError } from './HandledError';
 import { execAsCallback, exec } from './child-process-promisified';
-import { getRepoOwnerPath, getRepoPath } from './env';
+import { getRepoPath } from './env';
 import { stat } from './fs-promisified';
 import { getShortSha } from './github/commitFormatters';
 import { logger } from './logger';
@@ -55,8 +55,10 @@ export function cloneRepo(
     };
 
     const execProcess = execAsCallback(
-      `git clone ${getRemoteUrl(options, options.repoOwner)} --progress`,
-      { cwd: getRepoOwnerPath(options), maxBuffer: 100 * 1024 * 1024 },
+      `git clone ${getRemoteUrl(options, options.repoOwner)} ${getRepoPath(
+        options
+      )} --progress`,
+      { maxBuffer: 100 * 1024 * 1024 },
       cb
     );
 

--- a/src/services/github/v4/fetchRemoteProjectConfig.private.test.ts
+++ b/src/services/github/v4/fetchRemoteProjectConfig.private.test.ts
@@ -1,7 +1,7 @@
 import { getDevAccessToken } from '../../../test/private/getDevAccessToken';
-import { fetchProjectConfig } from './fetchProjectConfig';
+import { fetchRemoteProjectConfig } from './fetchRemoteProjectConfig';
 
-describe('fetchProjectConfig', () => {
+describe('fetchRemoteProjectConfig', () => {
   let devAccessToken: string;
 
   beforeEach(async () => {
@@ -9,7 +9,7 @@ describe('fetchProjectConfig', () => {
   });
 
   it('returns the backport config from "main" branch', async () => {
-    const projectConfig = await fetchProjectConfig({
+    const projectConfig = await fetchRemoteProjectConfig({
       repoOwner: 'backport-org',
       repoName: 'repo-with-project-config',
       accessToken: devAccessToken,
@@ -31,7 +31,7 @@ describe('fetchProjectConfig', () => {
   });
 
   it('returns the backport config from "branch-with-legacy-config" branch', async () => {
-    const projectConfig = await fetchProjectConfig({
+    const projectConfig = await fetchRemoteProjectConfig({
       repoOwner: 'backport-org',
       repoName: 'repo-with-project-config',
       accessToken: devAccessToken,
@@ -46,7 +46,7 @@ describe('fetchProjectConfig', () => {
   });
 
   it('throws an error if config does not exist', async () => {
-    const promise = fetchProjectConfig({
+    const promise = fetchRemoteProjectConfig({
       repoOwner: 'backport-org',
       repoName: 'repo-with-project-config',
       accessToken: devAccessToken,

--- a/src/services/github/v4/fetchRemoteProjectConfig.ts
+++ b/src/services/github/v4/fetchRemoteProjectConfig.ts
@@ -2,7 +2,7 @@ import { ConfigFileOptions } from '../../../entrypoint.module';
 import { withConfigMigrations } from '../../../options/config/readConfigFile';
 import { apiRequestV4 } from './apiRequestV4';
 
-export async function fetchProjectConfig(options: {
+export async function fetchRemoteProjectConfig(options: {
   accessToken: string;
   githubApiBaseUrlV4?: string;
   repoName: string;

--- a/src/services/github/v4/getOptionsFromGithub/getOptionsFromGithub.ts
+++ b/src/services/github/v4/getOptionsFromGithub/getOptionsFromGithub.ts
@@ -1,5 +1,4 @@
 import { AxiosError } from 'axios';
-import ora from 'ora';
 import { ConfigFileOptions } from '../../../../options/ConfigOptions';
 import { withConfigMigrations } from '../../../../options/config/readConfigFile';
 import { filterNil } from '../../../../utils/filterEmpty';
@@ -36,7 +35,7 @@ export async function getOptionsFromGithub(options: {
   const { accessToken, githubApiBaseUrlV4, repoName, repoOwner } = options;
 
   let res: GithubConfigOptionsResponse;
-  const spinner = ora().start('Initializing...');
+
   try {
     res = await apiRequestV4<GithubConfigOptionsResponse>({
       githubApiBaseUrlV4,
@@ -45,9 +44,7 @@ export async function getOptionsFromGithub(options: {
       variables: { repoOwner, repoName },
       handleError: false,
     });
-    spinner.stop();
   } catch (e) {
-    spinner.stop();
     const error = e as AxiosError<
       GithubV4Response<GithubConfigOptionsResponse | null>
     >;

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -3,6 +3,7 @@ import { isString } from 'lodash';
 import safeJsonStringify from 'safe-json-stringify';
 import winston, { format } from 'winston';
 import { ConfigFileOptions } from '../options/ConfigOptions';
+import { redact } from '../utils/redact';
 import { getLogfilePath } from './env';
 
 const { combine } = format;
@@ -50,10 +51,10 @@ export function updateLogger(options: ConfigFileOptions) {
   }
 }
 
-export function redactAccessToken(str: string) {
+function redactAccessToken(str: string) {
   // `redactAccessToken` might be called before access token is set
   if (accessToken) {
-    return str.replace(new RegExp(accessToken, 'g'), '<REDACTED>');
+    return redact(accessToken, str);
   }
 
   return str;

--- a/src/test/backport-e2e.private.test.ts
+++ b/src/test/backport-e2e.private.test.ts
@@ -4,27 +4,29 @@ import { resolve } from 'path';
 import { Octokit } from '@octokit/rest';
 import del = require('del');
 import nock from 'nock';
-import { getOptions } from '../../options/options';
-import { runSequentially } from '../../runSequentially';
-import { getCommits } from '../../ui/getCommits';
-import { mockConfigFiles } from '../mockConfigFiles';
-import { listenForCallsToNockScope } from '../nockHelpers';
-import { getDevAccessToken } from '../private/getDevAccessToken';
+import { getOptions } from '../options/options';
+import { runSequentially } from '../runSequentially';
+import { getCommits } from '../ui/getCommits';
+import { mockConfigFiles } from './mockConfigFiles';
+import { listenForCallsToNockScope } from './nockHelpers';
+import { getDevAccessToken } from './private/getDevAccessToken';
 
 jest.unmock('make-dir');
 jest.unmock('del');
 jest.setTimeout(10000);
 
-const INTEGRATION_TEST_DATA_PATH = resolve(
-  './src/test/integration/mock-environment'
+const E2E_TEST_DATA_PATH = resolve(
+  './src/test/tmp-mock-environments/backport-e2e'
 );
-const HOMEDIR_PATH = resolve('./src/test/integration/mock-environment/homedir');
+const HOMEDIR_PATH = resolve(
+  './src/test/tmp-mock-environments/backport-e2e/homedir'
+);
 const REPO_OWNER = 'backport-org';
 const REPO_NAME = 'integration-test';
 const BRANCH_NAME = 'backport/7.x/commit-5bf29b7d';
 const AUHTOR = 'sqren';
 
-describe('integration', () => {
+describe('backport e2e', () => {
   afterAll(() => {
     nock.cleanAll();
   });
@@ -389,5 +391,5 @@ async function resetState(accessToken: string) {
     branchName: BRANCH_NAME,
   });
 
-  await del(INTEGRATION_TEST_DATA_PATH);
+  await del(E2E_TEST_DATA_PATH);
 }

--- a/src/test/handleUnbackportedPullRequests.private.test.ts
+++ b/src/test/handleUnbackportedPullRequests.private.test.ts
@@ -1,0 +1,49 @@
+import { resolve } from 'path';
+import { getCommits, backportRun } from '../entrypoint.module';
+import { getDevAccessToken } from './private/getDevAccessToken';
+
+jest.unmock('find-up');
+jest.setTimeout(15000);
+
+describe('Handle unbackported pull requests', () => {
+  it('shows missing backports for PR number 8', async () => {
+    const accessToken = await getDevAccessToken();
+    const commits = await getCommits({
+      accessToken: accessToken,
+      repoOwner: 'backport-org',
+      repoName: 'repo-with-conflicts',
+      pullNumber: 8,
+    });
+
+    expect(commits[0]).toEqual({
+      committedDate: '2021-12-16T00:03:34Z',
+      expectedTargetPullRequests: [{ branch: '7.x', state: 'MISSING' }],
+      originalMessage: 'Change Barca to Braithwaite (#8)',
+      pullNumber: 8,
+      pullUrl: 'https://github.com/backport-org/repo-with-conflicts/pull/8',
+      sha: '343402a748be2375325b2730fa979bcea5b96ba1',
+      sourceBranch: 'main',
+    });
+  });
+
+  it('shows that backport failed because PR number 8 was not backported', async () => {
+    const accessToken = await getDevAccessToken();
+    const result = await backportRun({
+      accessToken: accessToken,
+      repoOwner: 'backport-org',
+      repoName: 'repo-with-conflicts',
+      pullNumber: 12,
+      targetBranches: ['7.x'],
+      dir: resolve(
+        './src/test/tmp-mock-environments/handleUnbackportedPullRequests'
+      ),
+      ci: true,
+      publishStatusComment: false,
+    });
+
+    expect(
+      //@ts-expect-error
+      result.results[0].error.meta?.commitsWithoutBackports[0].commit.pullNumber
+    ).toBe(8);
+  });
+});

--- a/src/ui/cherrypickAndCreateTargetPullRequest.ts
+++ b/src/ui/cherrypickAndCreateTargetPullRequest.ts
@@ -259,7 +259,7 @@ async function waitForCherrypick(
   if (commitsWithoutBackports.length > 0) {
     consoleLog(
       chalk.italic(
-        `Hint: Before fixing the conflicts manually you should consider backporting the following commits to "${targetBranch}":`
+        `Hint: Before fixing the conflicts manually you should consider backporting the following pull requests to "${targetBranch}":`
       )
     );
 

--- a/src/ui/maybeSetupRepo.ts
+++ b/src/ui/maybeSetupRepo.ts
@@ -1,7 +1,5 @@
-import makeDir from 'make-dir';
 import ora = require('ora');
 import { ValidConfigOptions } from '../options/options';
-import { getRepoOwnerPath } from '../services/env';
 import {
   addRemote,
   cloneRepo,
@@ -19,7 +17,6 @@ export async function maybeSetupRepo(options: ValidConfigOptions) {
     try {
       const spinnerCloneText = 'Cloning repository (one-time operation)';
       spinner.text = `0% ${spinnerCloneText}`;
-      await makeDir(getRepoOwnerPath(options));
 
       await cloneRepo(options, (progress: string) => {
         spinner.text = `${progress}% ${spinnerCloneText}`;

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,0 +1,3 @@
+export function redact(stringToRedact: string, str: string) {
+  return str.replace(new RegExp(stringToRedact, 'g'), '<REDACTED>');
+}


### PR DESCRIPTION
Closes https://github.com/sqren/backport/issues/269

This adds a new `--dir` option where the temporary repo will be checked out, and where conflicts should be resolved.
The global config file will still be retrieved from `~/.backport/config.json`

Summary:
 - Add options `dir` and `publishStatusComment`
 - redact access-token when posting status comment