### PR TITLE
Disable tests with mutations on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_script:
 script:
   - yarn tsc
   - yarn eslint './**/*.{ts,js}'
-  - 'if [ -n "$accessToken" ]; then echo "Running public and private tests" && yarn jest --config ./jest.config.all.js --coverage; fi'
-  - 'if [ -z "$accessToken" ]; then echo "Running only public tests (excluding private ones) " && yarn jest --config ./jest.config.js; fi'
+  - 'if [ -n "$accessToken" ]; then echo "Running public and private tests" && yarn test && yarn test-private; fi'
+  - 'if [ -z "$accessToken" ]; then echo "Running only public tests (excluding private ones) " && yarn test; fi'
 after_success:
   - npm install -g coveralls
   - cat coverage/lcov.info | coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
 script:
   - yarn tsc
   - yarn eslint './**/*.{ts,js}'
-  - 'if [ -n "$accessToken" ]; then echo "Running public and private tests" && yarn test && yarn test-private; fi'
+  - 'if [ -n "$accessToken" ]; then echo "Running public and private tests" && yarn test --coverage && yarn test-private; fi'
   - 'if [ -z "$accessToken" ]; then echo "Running only public tests (excluding private ones) " && yarn test; fi'
 after_success:
   - npm install -g coveralls

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,8 +5,9 @@ module.exports = {
   testRegex: 'src/.*test.ts$',
   testEnvironment: 'node',
 
-  // exclude private tests that requires credentials and can therefore not run on CI for external contributors
-  modulePathIgnorePatterns: ['.*.private.test.ts$'],
+  // exclude "private" tests that requires credentials and can therefore not run on CI for external contributors
+  // exclude "mutation" tests that cannot run on in parallel (like they are on CI) because they mutate shared state
+  modulePathIgnorePatterns: ['.*.private.test.ts$', '.*.mutation.test.ts$'],
 
   moduleFileExtensions: ['ts', 'js', 'json'],
   globals: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
+// ensure timezone is always in UTC
+process.env.TZ = 'UTC';
+
 module.exports = {
   snapshotSerializers: ['jest-snapshot-serializer-ansi'],
   setupFiles: ['./src/test/setupFiles/automatic-mocks.ts'],

--- a/jest.config.mutation.js
+++ b/jest.config.mutation.js
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const config = require('./jest.config');
+
+module.exports = {
+  ...config,
+
+  // only include "mutation" tests that cannot run on in parallel (like they are on CI) because they mutate shared state
+  testRegex: ['.*.mutation.test.ts$'],
+  modulePathIgnorePatterns: [],
+};

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prepublishOnly": "tsc --project ./tsconfig.prod.json",
     "test": "jest",
     "test-private": "jest --config ./jest.config.private.js",
+    "test-local": "jest --config ./jest.config.local.js",
     "test-all": "yarn lint && jest --config ./jest.config.all.js",
     "start": "ts-node --transpile-only ./src/entrypoint.cli.ts"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prepublishOnly": "tsc --project ./tsconfig.prod.json",
     "test": "jest",
     "test-private": "jest --config ./jest.config.private.js",
-    "test-local": "jest --config ./jest.config.local.js",
+    "test-mutation": "jest --config ./jest.config.mutation.js",
     "test-all": "yarn lint && jest --config ./jest.config.all.js",
     "start": "ts-node --transpile-only ./src/entrypoint.cli.ts"
   },

--- a/src/options/cliArgs.test.ts
+++ b/src/options/cliArgs.test.ts
@@ -177,4 +177,36 @@ describe('getOptionsFromCliArgs', () => {
       expect(res.targetBranches).toEqual(['6.0']);
     });
   });
+
+  describe('since/until', () => {
+    it('should always be UTC time (configured globally in jest.config.js)', () => {
+      expect(new Date().getTimezoneOffset()).toBe(0);
+    });
+
+    it('accepts ISO dates', () => {
+      const argv = [
+        '--since',
+        '2020-08-15T00:00:00.000Z',
+        '--until',
+        '2020-08-15T14:00:00.000Z',
+      ];
+      const res = getOptionsFromCliArgs(argv);
+      expect(res.dateSince).toEqual('2020-08-15T00:00:00.000Z');
+      expect(res.dateUntil).toEqual('2020-08-15T14:00:00.000Z');
+    });
+
+    it('accepts non-ISO dates', () => {
+      const argv = ['--since', '2020-08-15', '--until', '2020-08-15 14:00'];
+      const res = getOptionsFromCliArgs(argv);
+      expect(res.dateSince).toEqual('2020-08-15T00:00:00.000Z');
+      expect(res.dateUntil).toEqual('2020-08-15T14:00:00.000Z');
+    });
+
+    it('accepts years', () => {
+      const argv = ['--since', '2020', '--until', '2021'];
+      const res = getOptionsFromCliArgs(argv);
+      expect(res.dateSince).toEqual('2020-01-01T00:00:00.000Z');
+      expect(res.dateUntil).toEqual('2021-01-01T00:00:00.000Z');
+    });
+  });
 });

--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -375,8 +375,8 @@ export function getOptionsFromCliArgs(
 
     // filters
     author: all ? null : author,
-    dateSince: since,
-    dateUntil: until,
+    dateSince: since ? new Date(since).toISOString() : undefined,
+    dateUntil: until ? new Date(until).toISOString() : undefined,
 
     // `multiple` is a cli-only flag to override `multipleBranches` and `multipleCommits`
     multipleBranches: multiple ?? multipleBranches,

--- a/src/test/backport-e2e.mutation.test.ts
+++ b/src/test/backport-e2e.mutation.test.ts
@@ -135,78 +135,78 @@ describe('backport e2e', () => {
     });
   });
 
-  // describe.skip('when two commits are backported', () => {
-  //   let createPullRequestsMockCalls: unknown[];
-  //   let res: Awaited<ReturnType<typeof runSequentially>>;
-  //   let accessToken: string;
+  describe('when two commits are backported', () => {
+    let createPullRequestsMockCalls: unknown[];
+    let res: Awaited<ReturnType<typeof runSequentially>>;
+    let accessToken: string;
 
-  //   beforeAll(async () => {
-  //     accessToken = await getDevAccessToken();
-  //     await resetState(accessToken);
+    beforeAll(async () => {
+      accessToken = await getDevAccessToken();
+      await resetState(accessToken);
 
-  //     createPullRequestsMockCalls = mockCreatePullRequest({
-  //       number: 1337,
-  //       html_url: 'myHtmlUrl',
-  //     });
+      createPullRequestsMockCalls = mockCreatePullRequest({
+        number: 1337,
+        html_url: 'myHtmlUrl',
+      });
 
-  //     const options = {
-  //       githubApiBaseUrlV3: 'https://api.foo.com',
-  //       ci: true,
-  //       sha: '5bf29b7d847ea3dbde9280448f0f62ad0f22d3ad',
-  //       author: AUHTOR,
-  //       accessToken,
-  //       repoOwner: 'backport-org',
-  //       reponame: 'integration-test',
-  //     } as ValidConfigOptions;
-  //     const commits = await getCommits(options);
-  //     const targetBranches: string[] = ['7.x'];
+      const options = await getOptions([], {
+        githubApiBaseUrlV3: 'https://api.foo.com',
+        ci: true,
+        sha: '5bf29b7d847ea3dbde9280448f0f62ad0f22d3ad',
+        author: AUHTOR,
+        accessToken,
+        repoOwner: 'backport-org',
+        repoName: 'integration-test',
+      });
+      const commits = await getCommits(options);
+      const targetBranches: string[] = ['7.x'];
 
-  //     res = await runSequentially({ options, commits, targetBranches });
-  //   });
+      res = await runSequentially({ options, commits, targetBranches });
+    });
 
-  //   it('sends the correct http body when creating pull request', () => {
-  //     expect(createPullRequestsMockCalls).toMatchInlineSnapshot();
-  //   });
+    it('sends the correct http body when creating pull request', () => {
+      expect(createPullRequestsMockCalls).toMatchInlineSnapshot();
+    });
 
-  //   it('returns pull request', () => {
-  //     expect(res).toEqual([
-  //       { pullRequestUrl: 'myHtmlUrl', success: true, targetBranch: '6.0' },
-  //     ]);
-  //   });
+    it('returns pull request', () => {
+      expect(res).toEqual([
+        { pullRequestUrl: 'myHtmlUrl', success: true, targetBranch: '6.0' },
+      ]);
+    });
 
-  //   it('should not create new branches in origin (backport-org/integration-test)', async () => {
-  //     const branches = await getBranches({
-  //       accessToken,
-  //       repoOwner: REPO_OWNER,
-  //       repoName: REPO_NAME,
-  //     });
-  //     expect(branches.map((b) => b.name)).toEqual(['7.x', '* master']);
-  //   });
+    it('should not create new branches in origin (backport-org/integration-test)', async () => {
+      const branches = await getBranches({
+        accessToken,
+        repoOwner: REPO_OWNER,
+        repoName: REPO_NAME,
+      });
+      expect(branches.map((b) => b.name)).toEqual(['7.x', '* master']);
+    });
 
-  //   it('should create branch in the fork (sqren/integration-test)', async () => {
-  //     const branches = await getBranches({
-  //       accessToken,
-  //       repoOwner: AUHTOR,
-  //       repoName: REPO_NAME,
-  //     });
-  //     expect(branches.map((b) => b.name)).toEqual([
-  //       '7.x',
-  //       'backport/6.0/pr-85_commit-2e63475c',
-  //       'master',
-  //     ]);
-  //   });
+    it('should create branch in the fork (sqren/integration-test)', async () => {
+      const branches = await getBranches({
+        accessToken,
+        repoOwner: AUHTOR,
+        repoName: REPO_NAME,
+      });
+      expect(branches.map((b) => b.name)).toEqual([
+        '7.x',
+        'backport/6.0/pr-85_commit-2e63475c',
+        'master',
+      ]);
+    });
 
-  //   it('should have cherry picked the correct commit', async () => {
-  //     const branches = await getBranches({
-  //       accessToken,
-  //       repoOwner: AUHTOR,
-  //       repoName: REPO_NAME,
-  //     });
+    it('should have cherry picked the correct commit', async () => {
+      const branches = await getBranches({
+        accessToken,
+        repoOwner: AUHTOR,
+        repoName: REPO_NAME,
+      });
 
-  //     const sha = branches.find((branch) => branch.name === '7.x')?.commit.sha;
-  //     expect(sha).toEqual('foo');
-  //   });
-  // });
+      const sha = branches.find((branch) => branch.name === '7.x')?.commit.sha;
+      expect(sha).toEqual('foo');
+    });
+  });
 
   describe('when disabling fork mode', () => {
     let res: Awaited<ReturnType<typeof runSequentially>>;

--- a/src/test/backport-e2e.mutation.test.ts
+++ b/src/test/backport-e2e.mutation.test.ts
@@ -165,7 +165,22 @@ describe('backport e2e', () => {
     });
 
     it('sends the correct http body when creating pull request', () => {
-      expect(createPullRequestsMockCalls).toMatchInlineSnapshot();
+      expect(createPullRequestsMockCalls).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "base": "7.x",
+            "body": "# Backport
+
+        This is an automatic backport to \`7.x\` of:
+         - Add ❤️ emoji (5bf29b7d)
+
+        ### Questions ?
+        Please refer to the [Backport tool documentation](https://github.com/sqren/backport)",
+            "head": "sqren:backport/7.x/commit-5bf29b7d",
+            "title": "[7.x] Add ❤️ emoji",
+          },
+        ]
+      `);
     });
 
     it('returns pull request', () => {

--- a/src/test/backport-e2e.mutation.test.ts
+++ b/src/test/backport-e2e.mutation.test.ts
@@ -23,8 +23,9 @@ const HOMEDIR_PATH = resolve(
 );
 const REPO_OWNER = 'backport-org';
 const REPO_NAME = 'integration-test';
-const BRANCH_NAME = 'backport/7.x/commit-5bf29b7d';
-const AUHTOR = 'sqren';
+const BRANCH_WITH_ONE_COMMIT = 'backport/7.x/commit-5bf29b7d';
+const BRANCH_WITH_TWO_COMMITS = 'backport/7.x/commit-5bf29b7d_pr-2';
+const AUTHOR = 'sqren';
 
 describe('backport e2e', () => {
   afterAll(() => {
@@ -56,13 +57,13 @@ describe('backport e2e', () => {
       });
 
       const options = await getOptions([], {
-        githubApiBaseUrlV3: 'https://api.foo.com',
-        ci: true,
-        sha: '5bf29b7d847ea3dbde9280448f0f62ad0f22d3ad',
-        author: AUHTOR,
         accessToken,
-        repoOwner: 'backport-org',
+        author: AUTHOR,
+        ci: true,
+        githubApiBaseUrlV3: 'https://api.foo.com',
         repoName: 'integration-test',
+        repoOwner: 'backport-org',
+        sha: '5bf29b7d847ea3dbde9280448f0f62ad0f22d3ad',
       });
       const commits = await getCommits(options);
       const targetBranches: string[] = ['7.x'];
@@ -113,25 +114,14 @@ describe('backport e2e', () => {
     it('should create branch in the fork (sqren/integration-test)', async () => {
       const branches = await getBranches({
         accessToken,
-        repoOwner: AUHTOR,
+        repoOwner: AUTHOR,
         repoName: REPO_NAME,
       });
       expect(branches.map((b) => b.name)).toEqual([
         '7.x',
-        BRANCH_NAME,
+        BRANCH_WITH_ONE_COMMIT,
         'master',
       ]);
-    });
-
-    it('should have cherry picked the correct commit', async () => {
-      const branches = await getBranches({
-        accessToken,
-        repoOwner: AUHTOR,
-        repoName: REPO_NAME,
-      });
-
-      const sha = branches.find((branch) => branch.name === '7.x')?.commit.sha;
-      expect(sha).toEqual('b68e4fcaaf4427fe1e902c718b3bb3f07b560fb5');
     });
   });
 
@@ -150,21 +140,29 @@ describe('backport e2e', () => {
       });
 
       const options = await getOptions([], {
-        githubApiBaseUrlV3: 'https://api.foo.com',
-        ci: true,
-        sha: '5bf29b7d847ea3dbde9280448f0f62ad0f22d3ad',
-        author: AUHTOR,
         accessToken,
-        repoOwner: 'backport-org',
+        author: AUTHOR,
+        ci: true,
+        githubApiBaseUrlV3: 'https://api.foo.com',
         repoName: 'integration-test',
+        repoOwner: 'backport-org',
       });
-      const commits = await getCommits(options);
-      const targetBranches: string[] = ['7.x'];
+      const commits = [
+        ...(await getCommits({
+          ...options,
+          sha: '5bf29b7d847ea3dbde9280448f0f62ad0f22d3ad',
+        })),
+        ...(await getCommits({
+          ...options,
+          sha: '59d6ff1ca90a4ce210c0a4f0e159214875c19d60',
+        })),
+      ];
 
+      const targetBranches: string[] = ['7.x'];
       res = await runSequentially({ options, commits, targetBranches });
     });
 
-    it('sends the correct http body when creating pull request', () => {
+    it('contains both commits in the pull request body', () => {
       expect(createPullRequestsMockCalls).toMatchInlineSnapshot(`
         Array [
           Object {
@@ -173,19 +171,26 @@ describe('backport e2e', () => {
 
         This is an automatic backport to \`7.x\` of:
          - Add ❤️ emoji (5bf29b7d)
+         - #2
 
         ### Questions ?
         Please refer to the [Backport tool documentation](https://github.com/sqren/backport)",
-            "head": "sqren:backport/7.x/commit-5bf29b7d",
-            "title": "[7.x] Add ❤️ emoji",
+            "head": "sqren:backport/7.x/commit-5bf29b7d_pr-2",
+            "title": "[7.x] Add ❤️ emoji | Add family emoji (#2)",
           },
         ]
       `);
     });
 
-    it('returns pull request', () => {
+    it('returns the pull request response', () => {
       expect(res).toEqual([
-        { pullRequestUrl: 'myHtmlUrl', success: true, targetBranch: '6.0' },
+        {
+          didUpdate: false,
+          pullRequestNumber: 1337,
+          status: 'success',
+          pullRequestUrl: 'myHtmlUrl',
+          targetBranch: '7.x',
+        },
       ]);
     });
 
@@ -195,31 +200,20 @@ describe('backport e2e', () => {
         repoOwner: REPO_OWNER,
         repoName: REPO_NAME,
       });
-      expect(branches.map((b) => b.name)).toEqual(['7.x', '* master']);
+      expect(branches.map((b) => b.name)).toEqual(['7.x', 'master']);
     });
 
     it('should create branch in the fork (sqren/integration-test)', async () => {
       const branches = await getBranches({
         accessToken,
-        repoOwner: AUHTOR,
+        repoOwner: AUTHOR,
         repoName: REPO_NAME,
       });
       expect(branches.map((b) => b.name)).toEqual([
         '7.x',
-        'backport/6.0/pr-85_commit-2e63475c',
+        BRANCH_WITH_TWO_COMMITS,
         'master',
       ]);
-    });
-
-    it('should have cherry picked the correct commit', async () => {
-      const branches = await getBranches({
-        accessToken,
-        repoOwner: AUHTOR,
-        repoName: REPO_NAME,
-      });
-
-      const sha = branches.find((branch) => branch.name === '7.x')?.commit.sha;
-      expect(sha).toEqual('foo');
     });
   });
 
@@ -230,7 +224,6 @@ describe('backport e2e', () => {
 
     beforeAll(async () => {
       accessToken = await getDevAccessToken();
-
       await resetState(accessToken);
 
       createPullRequestsMockCalls = mockCreatePullRequest({
@@ -239,14 +232,14 @@ describe('backport e2e', () => {
       });
 
       const options = await getOptions([], {
-        author: AUHTOR,
-        githubApiBaseUrlV3: 'https://api.foo.com',
-        ci: true,
-        sha: '5bf29b7d847ea3dbde9280448f0f62ad0f22d3ad',
         accessToken,
-        repoOwner: 'backport-org',
-        repoName: 'integration-test',
+        author: AUTHOR,
+        ci: true,
         fork: false,
+        githubApiBaseUrlV3: 'https://api.foo.com',
+        repoName: 'integration-test',
+        repoOwner: 'backport-org',
+        sha: '5bf29b7d847ea3dbde9280448f0f62ad0f22d3ad',
       });
       const commits = await getCommits(options);
       const targetBranches: string[] = ['7.x'];
@@ -293,7 +286,7 @@ describe('backport e2e', () => {
       });
       expect(branches.map((b) => b.name)).toEqual([
         '7.x',
-        BRANCH_NAME,
+        BRANCH_WITH_ONE_COMMIT,
         'master',
       ]);
     });
@@ -301,20 +294,10 @@ describe('backport e2e', () => {
     it('should NOT create branch in the fork (sqren/integration-test)', async () => {
       const branches = await getBranches({
         accessToken,
-        repoOwner: AUHTOR,
+        repoOwner: AUTHOR,
         repoName: REPO_NAME,
       });
       expect(branches.map((b) => b.name)).toEqual(['7.x', 'master']);
-    });
-
-    it('should cherry pick the correct commit', async () => {
-      const branches = await getBranches({
-        accessToken,
-        repoOwner: REPO_OWNER,
-        repoName: REPO_NAME,
-      });
-      const sha = branches.find((branch) => branch.name === '7.x')?.commit.sha;
-      expect(sha).toEqual('b68e4fcaaf4427fe1e902c718b3bb3f07b560fb5');
     });
   });
 });
@@ -394,14 +377,21 @@ async function resetState(accessToken: string) {
     accessToken,
     repoOwner: REPO_OWNER,
     repoName: REPO_NAME,
-    branchName: BRANCH_NAME,
+    branchName: BRANCH_WITH_ONE_COMMIT,
   });
 
   await deleteBranch({
     accessToken,
-    repoOwner: AUHTOR,
+    repoOwner: AUTHOR,
     repoName: REPO_NAME,
-    branchName: BRANCH_NAME,
+    branchName: BRANCH_WITH_ONE_COMMIT,
+  });
+
+  await deleteBranch({
+    accessToken,
+    repoOwner: AUTHOR,
+    repoName: REPO_NAME,
+    branchName: BRANCH_WITH_TWO_COMMITS,
   });
 
   await del(E2E_TEST_DATA_PATH);

--- a/src/test/inquirer.private.test.ts
+++ b/src/test/inquirer.private.test.ts
@@ -137,9 +137,9 @@ describe('inquirer cli', () => {
         '--accessToken',
         devAccessToken,
         '--since',
-        '2020-08-15',
+        '2020-08-15T00:00:00.000Z',
         '--until',
-        '2020-08-15 14:00',
+        '2020-08-15T14:00:00.000Z',
       ],
       { waitForString: 'Select commit' }
     );

--- a/src/test/inquirer.private.test.ts
+++ b/src/test/inquirer.private.test.ts
@@ -4,6 +4,8 @@ import { getDevAccessToken } from './private/getDevAccessToken';
 
 const TIMEOUT_IN_SECONDS = 10;
 
+jest.setTimeout(15000);
+
 describe('inquirer cli', () => {
   let devAccessToken: string;
 

--- a/src/test/inquirer.private.test.ts
+++ b/src/test/inquirer.private.test.ts
@@ -146,14 +146,15 @@ describe('inquirer cli', () => {
 
     expect(output).toMatchInlineSnapshot(`
       "? Select commit (Use arrow keys)
-      ❯ 1. Add family emoji (#2) 7.x
-        2. Add \`backport\` dep
-        3. Merge pull request #1 from backport-org/add-heart-emoji
-        4. Update .backportrc.json
-        5. Bump to 8.0.0
-        6. Add package.json
-        7. Update .backportrc.json
-        8. Create .backportrc.json"
+      ❯ 1. Add 🍏 emoji (#5) 7.x, 7.8
+        2. Add family emoji (#2) 7.x
+        3. Add \`backport\` dep
+        4. Merge pull request #1 from backport-org/add-heart-emoji
+        5. Update .backportrc.json
+        6. Bump to 8.0.0
+        7. Add package.json
+        8. Update .backportrc.json
+        9. Create .backportrc.json"
     `);
   });
 

--- a/src/test/inquirer.private.test.ts
+++ b/src/test/inquirer.private.test.ts
@@ -35,8 +35,6 @@ describe('inquirer cli', () => {
       'backport-org',
       '--repo-name',
       'backport-e2e',
-      '--author',
-      'sqren',
       '--accessToken',
       devAccessToken,
     ]);
@@ -69,8 +67,6 @@ describe('inquirer cli', () => {
       'foo',
       '--repo-name',
       'bar',
-      '--author',
-      'some-user',
       '--accessToken',
       'some-token',
     ]);
@@ -125,6 +121,39 @@ describe('inquirer cli', () => {
         4. Add family emoji (#2) 7.x
         5. Add \`backport\` dep
         6. Merge pull request #1 from backport-org/add-heart-emoji"
+    `);
+  });
+
+  it(`should limit commits by since and until`, async () => {
+    jest.setTimeout(TIMEOUT_IN_SECONDS * 1000 * 1.1);
+    const output = await runBackportAsync(
+      [
+        '--branch',
+        'foo',
+        '--repo-owner',
+        'backport-org',
+        '--repo-name',
+        'backport-e2e',
+        '--accessToken',
+        devAccessToken,
+        '--since',
+        '2020-08-15',
+        '--until',
+        '2020-08-15 14:00',
+      ],
+      { waitForString: 'Select commit' }
+    );
+
+    expect(output).toMatchInlineSnapshot(`
+      "? Select commit (Use arrow keys)
+      ❯ 1. Add family emoji (#2) 7.x
+        2. Add \`backport\` dep
+        3. Merge pull request #1 from backport-org/add-heart-emoji
+        4. Update .backportrc.json
+        5. Bump to 8.0.0
+        6. Add package.json
+        7. Update .backportrc.json
+        8. Create .backportrc.json"
     `);
   });
 


### PR DESCRIPTION
Some tests mutate shared state (eg changes the state of Github pull requests) and can thus not be run in parallel. They still have value but should only be run locally.