### PR TITLE
fix: only show shield.io badge for public repos

### DIFF
--- a/src/lib/github/v3/createStatusComment.test.ts
+++ b/src/lib/github/v3/createStatusComment.test.ts
@@ -609,7 +609,7 @@ describe('getCommentBody', () => {
     });
   });
 
-  describe('when repo is private or public', () => {
+  describe('shield.io badges', () => {
     const getParams = (opts: Partial<ValidConfigOptions>) => ({
       options: {
         interactive: true,
@@ -634,7 +634,7 @@ describe('getCommentBody', () => {
       } as BackportResponse,
     });
 
-    it('posts a comment without shields.io badge`', () => {
+    it('posts a comment without shields.io badge when repo is private`', () => {
       const params = getParams({ isRepoPrivate: true });
       expect(getCommentBody(params)).not.toContain('img.shields.io');
       expect(getCommentBody(params)).toMatchInlineSnapshot(`
@@ -653,7 +653,7 @@ describe('getCommentBody', () => {
       `);
     });
 
-    it('posts a comment with shields.io badge`', () => {
+    it('posts a comment with shields.io badge when repo is public`', () => {
       const params = getParams({ isRepoPrivate: false });
       expect(getCommentBody(params)).toContain('img.shields.io');
       expect(getCommentBody(params)).toMatchInlineSnapshot(`

--- a/src/lib/github/v3/createStatusComment.ts
+++ b/src/lib/github/v3/createStatusComment.ts
@@ -66,6 +66,7 @@ export function getCommentBody({
     repoName,
     repoOwner,
     autoMerge,
+    isRepoPrivate,
     publishStatusCommentOnAbort,
     publishStatusCommentOnFailure,
     publishStatusCommentOnSuccess,
@@ -127,10 +128,12 @@ ${manualBackportCommand}${questionsAndLinkToBackport}${packageVersionSection}`;
   const tableBody = backportResponse.results
     .map((result) => {
       if (result.status === 'success') {
+        const prShield = `[<img src="https://img.shields.io/github/pulls/detail/state/${repoOwner}/${repoName}/${result.pullRequestNumber}">](${result.pullRequestUrl})`;
+
         return [
           '✅',
           result.targetBranch,
-          `[<img src="https://img.shields.io/github/pulls/detail/state/${repoOwner}/${repoName}/${result.pullRequestNumber}">](${result.pullRequestUrl})`,
+          isRepoPrivate ? result.pullRequestUrl : prShield,
         ];
       }
 

--- a/src/lib/github/v4/getOptionsFromGithub/getOptionsFromGithub.private.test.ts
+++ b/src/lib/github/v4/getOptionsFromGithub/getOptionsFromGithub.private.test.ts
@@ -45,6 +45,7 @@ describe('getOptionsFromGithub', () => {
             '^v7.9.0$': '7.x',
             '^v8.0.0$': 'master',
           },
+          isRepoPrivate: false,
           sourceBranch: 'master',
           targetBranchChoices: [
             { checked: true, name: 'master' },
@@ -127,6 +128,7 @@ describe('getOptionsFromGithub', () => {
 
       expect(options).toEqual({
         authenticatedUsername: 'sqren',
+        isRepoPrivate: false,
         sourceBranch: 'main',
       });
     });

--- a/src/lib/github/v4/getOptionsFromGithub/getOptionsFromGithub.ts
+++ b/src/lib/github/v4/getOptionsFromGithub/getOptionsFromGithub.ts
@@ -78,6 +78,7 @@ export async function getOptionsFromGithub(options: {
   return {
     authenticatedUsername: res.viewer.login,
     sourceBranch: res.repository.defaultBranchRef.name,
+    isRepoPrivate: res.repository.isPrivate,
     ...remoteConfig,
   };
 }

--- a/src/lib/github/v4/getOptionsFromGithub/query.ts
+++ b/src/lib/github/v4/getOptionsFromGithub/query.ts
@@ -9,6 +9,7 @@ export interface GithubConfigOptionsResponse {
     login: string;
   };
   repository: {
+    isPrivate: boolean;
     illegalBackportBranch: { id: string } | null;
     defaultBranchRef: {
       name: string;
@@ -27,6 +28,7 @@ export const query = gql`
       illegalBackportBranch: ref(qualifiedName: "refs/heads/backport") {
         id
       }
+      isPrivate
       defaultBranchRef {
         name
         target {

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -221,6 +221,7 @@ describe('getOptions', () => {
       gitHostname: 'github.com',
       githubApiBaseUrlV4: 'http://localhost/graphql',
       interactive: true,
+      isRepoPrivate: false,
       maxNumber: 10,
       multipleBranches: true,
       multipleCommits: false,
@@ -454,6 +455,7 @@ function mockGithubConfigOptions({
           login: viewerLogin,
         },
         repository: {
+          isPrivate: false,
           illegalBackportBranch: hasBackportBranch ? { id: 'foo' } : null,
           defaultBranchRef: {
             name: defaultBranchRef,


### PR DESCRIPTION
Closes https://github.com/sqren/backport/issues/320

Shield.io badges cannot be displayed for private repos and currently show an error like:


| Status | Branch | Result |
|:------:|:------:|:------|
|✅|7.x|[<img src="https://img.shields.io/github/pulls/detail/state/sqren/backport-private/297">](https://github.com/sqren/backport/pull/297)|



This PR changes this, so badges are only displayed for public repos. For private repos the link to the PR will simply be displayed.


## Public repos
| Status | Branch | Result |
|:------:|:------:|:------|
|✅|7.x|[<img src="https://img.shields.io/github/pulls/detail/state/sqren/backport/297">](https://github.com/sqren/backport/pull/297)|


## Private repos

| Status | Branch | Result |
|:------:|:------:|:------|
|✅|7.x|https://github.com/sqren/backport/pull/297|
