### PR TITLE
Ensure english locale

### DIFF
--- a/src/lib/child-process-promisified.ts
+++ b/src/lib/child-process-promisified.ts
@@ -10,6 +10,9 @@ export async function exec(
   const res = await execPromisified(cmd, {
     maxBuffer: 100 * 1024 * 1024,
     ...options,
+
+    // ensure that git commands return english error messages
+    env: { ...process.env, LANG: 'en_US' },
   });
 
   return res;
@@ -29,7 +32,12 @@ export async function spawnPromise(
   logger.info(`Running command: "${fullCmd}"`);
 
   return new Promise(function (resolve, reject) {
-    const subprocess = childProcess.spawn(cmd, cmdArgs, { cwd });
+    const subprocess = childProcess.spawn(cmd, cmdArgs, {
+      cwd,
+
+      // ensure that git commands return english error messages
+      env: { ...process.env, LANG: 'en_US' },
+    });
     let stderr = '';
     let stdout = '';
 
@@ -57,7 +65,11 @@ export async function spawnPromise(
   });
 }
 
-export const spawnOriginal = childProcess.spawn;
+export const spawnStream = (cmd: string, cmdArgs: ReadonlyArray<string>) => {
+  return childProcess.spawn(cmd, cmdArgs, {
+    env: { ...process.env, LANG: 'en_US' },
+  });
+};
 
 export type SpawnErrorContext = {
   cmdArgs: string[];

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -8,7 +8,7 @@ import { CommitAuthor } from './author';
 import {
   spawnPromise,
   SpawnError,
-  spawnOriginal,
+  spawnStream,
 } from './child-process-promisified';
 import { getRepoPath } from './env';
 import { getShortSha } from './github/commitFormatters';
@@ -30,7 +30,7 @@ export async function cloneRepo(
   logger.info(`Cloning repo from ${sourcePath} to ${targetPath}`);
 
   return new Promise<void>((resolve, reject) => {
-    const subprocess = spawnOriginal('git', [
+    const subprocess = spawnStream('git', [
       'clone',
       sourcePath,
       targetPath,

--- a/src/lib/setupRepo.test.ts
+++ b/src/lib/setupRepo.test.ts
@@ -27,7 +27,7 @@ describe('setupRepo', () => {
       expect.assertions(2);
 
       jest
-        .spyOn(childProcess, 'spawnOriginal')
+        .spyOn(childProcess, 'spawnStream')
         .mockImplementation((cmd, cmdArgs) => {
           if (cmdArgs.includes('clone')) {
             throw new Error('Simulated git clone failure');
@@ -66,7 +66,7 @@ describe('setupRepo', () => {
         .mockResolvedValue(undefined);
 
       jest
-        .spyOn(childProcess, 'spawnOriginal')
+        .spyOn(childProcess, 'spawnStream')
         //@ts-expect-error
         .mockImplementation(() => {
           return {
@@ -206,7 +206,7 @@ describe('setupRepo', () => {
 
   function mockGitClone() {
     jest
-      .spyOn(childProcess, 'spawnOriginal')
+      .spyOn(childProcess, 'spawnStream')
       //@ts-expect-error
       .mockImplementation((cmd, cmdArgs) => {
         if (cmdArgs.includes('clone')) {
@@ -246,7 +246,7 @@ describe('setupRepo', () => {
         '100% Cloning repository from github.com (one-time operation)'
       );
 
-      expect(childProcess.spawnOriginal).toHaveBeenCalledWith('git', [
+      expect(childProcess.spawnStream).toHaveBeenCalledWith('git', [
         'clone',
         'https://x-access-token:myAccessToken@github.com/elastic/kibana.git',
         '/myHomeDir/.backport/repositories/elastic/kibana',
@@ -284,7 +284,7 @@ describe('setupRepo', () => {
         '100% Cloning repository from /path/to/source/repo (one-time operation)'
       );
 
-      expect(childProcess.spawnOriginal).toHaveBeenCalledWith('git', [
+      expect(childProcess.spawnStream).toHaveBeenCalledWith('git', [
         'clone',
         '/path/to/source/repo',
         '/myHomeDir/.backport/repositories/elastic/kibana',


### PR DESCRIPTION
Backport currently expects an English locale, since it parses error messages from git. To ensure English local all git messages not set the `LANG` environment variable to `en_US.UTF-8`. This means that the following will not cause errors:

```
LANG=it.UTF-8 backport 
```