### PR TITLE
Allow running backport from backport dir

### DIFF
--- a/src/lib/setupRepo.ts
+++ b/src/lib/setupRepo.ts
@@ -16,14 +16,14 @@ export async function setupRepo(options: ValidConfigOptions) {
   const repoPath = getRepoPath(options);
   const isAlreadyCloned = await getIsRepoCloned(options);
 
-  if (options.cwd.includes(repoPath)) {
-    throw new BackportError(
-      `Refusing to clone repo into "${repoPath}" when current working directory is "${options.cwd}". Please change backport directory via \`--dir\` option or run backport from another location`
-    );
-  }
-
   // clone repo if folder does not already exists
   if (!isAlreadyCloned) {
+    if (options.cwd.includes(repoPath)) {
+      throw new BackportError(
+        `Refusing to clone repo into "${repoPath}" when current working directory is "${options.cwd}". Please change backport directory via \`--dir\` option or run backport from another location`
+      );
+    }
+
     const spinner = ora(options.interactive).start();
     try {
       const localRepoPath = await getLocalSourceRepoPath(options);


### PR DESCRIPTION
When running backport from inside the backport dir an error is thrown:


> Refusing to clone repo into "/Users/sqren/.backport/repositories/elastic/kibana" when current working directory is "/Users/sqren/.backport/repositories/elastic/kibana". Please change backport directory via `--dir` option or run backport from another location

This is overly restrictive. It should be possible to run backport from within the backport dir itself if it exists.