### PR TITLE
Prefer commit author from source commit

### DIFF
--- a/src/lib/__snapshots__/cherrypickAndCreateTargetPullRequest.test.ts.snap
+++ b/src/lib/__snapshots__/cherrypickAndCreateTargetPullRequest.test.ts.snap
@@ -5,14 +5,6 @@ Array [
   Array [
     "git",
     Array [
-      "remote",
-      "--verbose",
-    ],
-    undefined,
-  ],
-  Array [
-    "git",
-    Array [
       "reset",
       "--hard",
     ],

--- a/src/lib/author.ts
+++ b/src/lib/author.ts
@@ -1,31 +1,13 @@
 import { Commit } from '../entrypoint.module';
 import { ValidConfigOptions } from '../options/options';
-import { getGitConfig, getLocalSourceRepoPath } from './git';
 
-export type GitConfigAuthor = { name?: string; email?: string };
-export async function getGitConfigAuthor(
-  options: ValidConfigOptions
-): Promise<GitConfigAuthor | undefined> {
-  const localRepoPath = await getLocalSourceRepoPath(options);
-  if (!localRepoPath) {
-    return;
-  }
-
-  return {
-    name: await getGitConfig({ dir: localRepoPath, key: 'user.name' }),
-    email: await getGitConfig({ dir: localRepoPath, key: 'user.email' }),
-  };
-}
-
-export type CommitAuthor = Required<GitConfigAuthor>;
+export type CommitAuthor = { name: string; email: string };
 export function getCommitAuthor({
   options,
   commit,
-  gitConfigAuthor,
 }: {
   options: ValidConfigOptions;
   commit: Commit;
-  gitConfigAuthor?: GitConfigAuthor;
 }): CommitAuthor {
   if (options.resetAuthor) {
     return {
@@ -35,8 +17,7 @@ export function getCommitAuthor({
   }
 
   return {
-    name: options.gitAuthorName ?? gitConfigAuthor?.name ?? commit.author.name,
-    email:
-      options.gitAuthorEmail ?? gitConfigAuthor?.email ?? commit.author.email,
+    name: options.gitAuthorName ?? commit.author.name,
+    email: options.gitAuthorEmail ?? commit.author.email,
   };
 }

--- a/src/lib/git.private.test.ts
+++ b/src/lib/git.private.test.ts
@@ -13,7 +13,6 @@ import {
   commitChanges,
   createBackportBranch,
   getShasInMergeCommit,
-  getGitConfig,
   getGitProjectRootPath,
   getIsCommitInBranch,
   getIsMergeCommit,
@@ -112,38 +111,6 @@ describe('git.private', () => {
       const res = await deleteRemote(options, 'my-remote-foo');
 
       expect(res).toBe(undefined);
-    });
-  });
-
-  describe('getGitConfig', () => {
-    const cwd = getSandboxPath({
-      filename: __filename,
-      specname: 'getGitConfig',
-    });
-
-    beforeEach(async () => {
-      await resetSandbox(cwd);
-      await gitInit(cwd);
-      await childProcess.exec(`git config user.name "John Doe"`, { cwd });
-      await childProcess.exec(`git config user.email "john@jubii.dk"`, { cwd });
-    });
-
-    it('should retrive name', async () => {
-      const name = await getGitConfig({
-        dir: cwd,
-        key: 'user.name',
-      });
-
-      expect(name).toEqual('John Doe');
-    });
-
-    it('should retrive  email', async () => {
-      const email = await getGitConfig({
-        dir: cwd,
-        key: 'user.email',
-      });
-
-      expect(email).toEqual('john@jubii.dk');
     });
   });
 

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -491,22 +491,6 @@ export async function getUnstagedFiles(options: ValidConfigOptions) {
   return uniq(files);
 }
 
-export async function getGitConfig({
-  dir,
-  key,
-}: {
-  dir: string;
-  key: 'user.name' | 'user.email';
-}) {
-  try {
-    const cwd = dir;
-    const res = await spawnPromise('git', ['config', key], cwd);
-    return res.stdout.trim();
-  } catch (e) {
-    return;
-  }
-}
-
 // How the commit flows:
 // ${sourceBranch} ->   ${backportBranch}   -> ${targetBranch}
 //     master      ->  backport/7.x/pr-1234 ->      7.x

--- a/src/lib/setupRepo.test.ts
+++ b/src/lib/setupRepo.test.ts
@@ -265,10 +265,6 @@ describe('setupRepo', () => {
         .spyOn(gitModule, 'getLocalSourceRepoPath')
         .mockResolvedValue('/path/to/source/repo');
 
-      jest
-        .spyOn(gitModule, 'getGitConfig')
-        .mockResolvedValue('email-or-username');
-
       mockGitClone();
 
       await setupRepo({

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -90,7 +90,7 @@ export async function getOptions({
   });
 
   const options = {
-    // default author
+    // default author to filter commits by
     author: optionsFromGithub.authenticatedUsername,
 
     // default fork owner


### PR DESCRIPTION
Currently the backport commit author defaults to using the info from the git config. This PR changes that so the backport commit author will instead inherit the author from the source commit.
To override this behaviour the user can set the commit author explicitly like `backport --git-author-name="Donald Duck" --git-author-email="duck@disney.com"`