### PR TITLE
Fix cloning vs pulling by normalizing path

### DIFF
--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,4 +1,4 @@
-import { resolve as pathResolve } from 'path';
+import path, { resolve as pathResolve } from 'path';
 import { uniq, isEmpty } from 'lodash';
 import { ora } from '../lib/ora';
 import { ValidConfigOptions } from '../options/options';
@@ -156,7 +156,7 @@ export async function getGitProjectRootPath(dir: string) {
       ['rev-parse', '--show-toplevel'],
       cwd
     );
-    return stdout.trim();
+    return path.normalize(stdout.trim());
   } catch (e) {
     logger.error('An error occurred while retrieving git project root', e);
     return;


### PR DESCRIPTION
Fixing [issue 440](https://github.com/sqren/backport/issues/440):
Problem:
On Windows 10 Backport will always clone, because the projectRoot & repoPath never will be equal, even though they do exist.
A problem with \ vs / . 
My solution is to add path.normalize() which should work on both Windows and POSIX.
Feel free to adapt my solution as needed.

Test executed:
Run 1st time: Repo cloned
Run 2nd time: Repo pulled
Run 3th time (after deleting the repo): Repo cloned