### PR TITLE
Update config-file-options.md

### DIFF
--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -202,10 +202,6 @@ Automatically detech which branches a pull request should be backported to, base
 
 _Note: backslashes must be escaped._
 
-#### `config-file`
-
-Custom path to project config file (.backportrc.json).
-
 #### `dir`
 
 Clone repository into custom directory


### PR DESCRIPTION
Fixing [issue 439](https://github.com/sqren/backport/issues/439):
Remove `config-file` from the config-file documentation as it can only be used with CLI