### PR TITLE
Add support for committing conflicts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Run entrypoint.cli.ts",
+      "name": "yarn start (entrypoint.cli.ts)",
       "program": "${workspaceRoot}/src/entrypoint.cli.ts",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
       "args": ["--no-fork", "--pr=96", "--repo=backport-org/backport-demo"],

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,7 @@ process.env.TZ = 'UTC';
 process.env.NODE_ENV = 'jest';
 
 const baseConfig: JestConfigWithTsJest = {
+  prettierPath: null,
   transform: {
     '^.+\\.ts?$': ['ts-jest', { diagnostics: false }],
   },

--- a/src/lib/cherrypickAndCreateTargetPullRequest/cherrypickAndCreateTargetPullRequest.ts
+++ b/src/lib/cherrypickAndCreateTargetPullRequest/cherrypickAndCreateTargetPullRequest.ts
@@ -52,8 +52,11 @@ export async function cherrypickAndCreateTargetPullRequest({
     await Promise.all(commits.map((c) => getMergeCommits(options, c))),
   );
 
-  await sequentially(commitsFlattened, (commit) =>
+  const cherrypickResults = await sequentially(commitsFlattened, (commit) =>
     waitForCherrypick(options, commit, targetBranch),
+  );
+  const hasAnyCommitWithConflicts = cherrypickResults.some(
+    (r) => r.hasCommitsWithConflicts,
   );
 
   if (!options.dryRun) {
@@ -110,7 +113,7 @@ export async function cherrypickAndCreateTargetPullRequest({
   }
 
   // make PR auto mergable
-  if (options.autoMerge) {
+  if (options.autoMerge && hasAnyCommitWithConflicts) {
     await autoMergeNowOrLater(options, targetPullRequest.number);
   }
 

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -358,6 +358,11 @@ export async function cherrypick({
   }
 }
 
+export async function gitAddAll({ options }: { options: ValidConfigOptions }) {
+  const cwd = getRepoPath(options);
+  return spawnPromise('git', ['add', '--all'], cwd);
+}
+
 async function gitCommit({
   options,
   commitAuthor,

--- a/src/lib/sequentially.ts
+++ b/src/lib/sequentially.ts
@@ -1,9 +1,10 @@
-export function sequentially<T>(
+export async function sequentially<T, R>(
   items: T[],
-  handler: (item: T) => Promise<void>,
-) {
-  return items.reduce(async (p, item) => {
-    await p;
-    return handler(item);
-  }, Promise.resolve());
+  handler: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (const item of items) {
+    results.push(await handler(item));
+  }
+  return results;
 }

--- a/src/options/ConfigOptions.ts
+++ b/src/options/ConfigOptions.ts
@@ -28,6 +28,7 @@ type Options = Partial<{
   autoMergeMethod: string;
   backportBinary: string;
   cherrypickRef: boolean;
+  commitConflicts: boolean;
   commitPaths: string[];
   details: boolean;
   dir: string;

--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -69,6 +69,12 @@ export function getOptionsFromCliArgs(processArgs: readonly string[]) {
       conflicts: ['noCherrypickRef'],
     })
 
+    .option('commitConflicts', {
+      description:
+        'Commit conflicts instead of aborting. Only takes effect in `non-interactive` mode. Defaults to false',
+      type: 'boolean',
+    })
+
     .option('cwd', {
       hidden: true,
       description: 'Path to source repo',

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -211,6 +211,7 @@ describe('getOptions', () => {
       autoMergeMethod: 'merge',
       backportBinary: 'backport',
       cherrypickRef: true,
+      commitConflicts: false,
       commitPaths: [],
       cwd: expect.any(String),
       dateSince: null,

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -31,6 +31,7 @@ export const defaultConfigOptions = {
   autoMergeMethod: 'merge',
   backportBinary: 'backport',
   cherrypickRef: true,
+  commitConflicts: false,
   commitPaths: [] as Array<string>,
   cwd: process.cwd(),
   dateSince: null,

--- a/src/test/e2e/cli/entrypoint.cli.private.test.ts
+++ b/src/test/e2e/cli/entrypoint.cli.private.test.ts
@@ -33,76 +33,78 @@ describe('entrypoint cli', () => {
   it('--help', async () => {
     const { output } = await runBackportViaCli([`--help`]);
     expect(output).toMatchInlineSnapshot(`
-      "entrypoint.cli.ts [args]
+"entrypoint.cli.ts [args]
 
-      Options:
-        -v, --version                         Show version number                                [boolean]
-            --accessToken, --accesstoken      Github access token                                 [string]
-        -a, --all                             List all commits                                   [boolean]
-            --assignee, --assign              Add assignees to the target pull request             [array]
-            --autoAssign                      Auto assign the target pull request to yourself    [boolean]
-            --autoMerge                       Enable auto-merge for created pull requests        [boolean]
-            --autoMergeMethod                 Sets auto-merge method when using --auto-merge. Default:
-                                              merge        [string] [choices: "merge", "rebase", "squash"]
-            --cherrypickRef                   Append commit message with "(cherry picked from commit...)
-                                                                                                 [boolean]
-            --projectConfigFile, --config     Path to project config                              [string]
-            --globalConfigFile                Path to global config                               [string]
-            --dateSince, --since              ISO-8601 date for filtering commits                 [string]
-            --dateUntil, --until              ISO-8601 date for filtering commits                 [string]
-            --dir                             Path to temporary backport repo                     [string]
-            --details                         Show details about each commit                     [boolean]
-            --dryRun                          Run backport locally without pushing to Github     [boolean]
-            --editor                          Editor to be opened during conflict resolution      [string]
-            --skipRemoteConfig                Use local .backportrc.json config instead of loading from
-                                              Github                                             [boolean]
-            --fork                            Create backports in fork or origin repo. Defaults to true
-                                                                                                 [boolean]
-            --gitAuthorName                   Set commit author name                              [string]
-            --gitAuthorEmail                  Set commit author email                             [string]
-            --nonInteractive, --json          Disable interactive prompts and return response as JSON
-                                                                                                 [boolean]
-            --ls                              List commits instead of backporting them           [boolean]
-            --mainline                        Parent id of merge commit. Defaults to 1 when supplied
-                                              without arguments                                   [number]
-        -s, --signoff                         Pass the --signoff option to the cherry-pick command
-                                                                                                 [boolean]
-        -n, --maxNumber, --number             Number of commits to choose from                    [number]
-            --multiple                        Select multiple branches/commits                   [boolean]
-            --multipleBranches                Backport to multiple branches                      [boolean]
-            --multipleCommits                 Backport multiple commits                          [boolean]
-            --noCherrypickRef                 Do not append commit message with "(cherry picked from
-                                              commit...)"                                        [boolean]
-            --noStatusComment                 Don't publish status comment to Github             [boolean]
-            --noVerify                        Bypass the pre-commit and commit-msg hooks         [boolean]
-            --noFork                          Create backports in the origin repo                [boolean]
-            --noTelemetry                     Disable telemetry                                  [boolean]
-            --onlyMissing                     Only list commits with missing or unmerged backports
-                                                                                                 [boolean]
-        -p, --path                            Only list commits touching files under the specified path
-                                                                                                   [array]
-            --prDescription, --description    Description to be added to pull request             [string]
-            --prTitle, --title                Title of pull request                               [string]
-            --prFilter                        Filter source pull requests by a query              [string]
-            --pullNumber, --pr                Pull request to backport                            [number]
-            --resetAuthor                     Set yourself as commit author                      [boolean]
-            --reviewer                        Add reviewer to the target PR                        [array]
-            --repoForkOwner                   The owner of the fork where the backport branch is pushed.
-                                              Defaults to the currently authenticated user        [string]
-            --repo                            Repo owner and name                                 [string]
-            --sha, --commit                   Commit sha to backport                              [string]
-            --sourceBranch                    Specify a non-default branch (normally "master") to backport
-                                              from                                                [string]
-            --sourcePRLabel, --sourcePrLabel  Add labels to the source (original) PR               [array]
-        -b, --targetBranch, --branch          Branch(es) to backport to                            [array]
-            --targetBranchChoice              List branches to backport to                         [array]
-        -l, --targetPRLabel, --label          Add labels to the target (backport) PR               [array]
-            --verify                          Opposite of no-verify                              [boolean]
-            --help                            Show help                                          [boolean]
+Options:
+  -v, --version                         Show version number                                [boolean]
+      --accessToken, --accesstoken      Github access token                                 [string]
+  -a, --all                             List all commits                                   [boolean]
+      --assignee, --assign              Add assignees to the target pull request             [array]
+      --autoAssign                      Auto assign the target pull request to yourself    [boolean]
+      --autoMerge                       Enable auto-merge for created pull requests        [boolean]
+      --autoMergeMethod                 Sets auto-merge method when using --auto-merge. Default:
+                                        merge        [string] [choices: "merge", "rebase", "squash"]
+      --cherrypickRef                   Append commit message with "(cherry picked from commit...)
+                                                                                           [boolean]
+      --commitConflicts                 Commit conflicts instead of aborting. Only takes effect in
+                                        \`non-interactive\` mode. Defaults to false          [boolean]
+      --projectConfigFile, --config     Path to project config                              [string]
+      --globalConfigFile                Path to global config                               [string]
+      --dateSince, --since              ISO-8601 date for filtering commits                 [string]
+      --dateUntil, --until              ISO-8601 date for filtering commits                 [string]
+      --dir                             Path to temporary backport repo                     [string]
+      --details                         Show details about each commit                     [boolean]
+      --dryRun                          Run backport locally without pushing to Github     [boolean]
+      --editor                          Editor to be opened during conflict resolution      [string]
+      --skipRemoteConfig                Use local .backportrc.json config instead of loading from
+                                        Github                                             [boolean]
+      --fork                            Create backports in fork or origin repo. Defaults to true
+                                                                                           [boolean]
+      --gitAuthorName                   Set commit author name                              [string]
+      --gitAuthorEmail                  Set commit author email                             [string]
+      --nonInteractive, --json          Disable interactive prompts and return response as JSON
+                                                                                           [boolean]
+      --ls                              List commits instead of backporting them           [boolean]
+      --mainline                        Parent id of merge commit. Defaults to 1 when supplied
+                                        without arguments                                   [number]
+  -s, --signoff                         Pass the --signoff option to the cherry-pick command
+                                                                                           [boolean]
+  -n, --maxNumber, --number             Number of commits to choose from                    [number]
+      --multiple                        Select multiple branches/commits                   [boolean]
+      --multipleBranches                Backport to multiple branches                      [boolean]
+      --multipleCommits                 Backport multiple commits                          [boolean]
+      --noCherrypickRef                 Do not append commit message with "(cherry picked from
+                                        commit...)"                                        [boolean]
+      --noStatusComment                 Don't publish status comment to Github             [boolean]
+      --noVerify                        Bypass the pre-commit and commit-msg hooks         [boolean]
+      --noFork                          Create backports in the origin repo                [boolean]
+      --noTelemetry                     Disable telemetry                                  [boolean]
+      --onlyMissing                     Only list commits with missing or unmerged backports
+                                                                                           [boolean]
+  -p, --path                            Only list commits touching files under the specified path
+                                                                                             [array]
+      --prDescription, --description    Description to be added to pull request             [string]
+      --prTitle, --title                Title of pull request                               [string]
+      --prFilter                        Filter source pull requests by a query              [string]
+      --pullNumber, --pr                Pull request to backport                            [number]
+      --resetAuthor                     Set yourself as commit author                      [boolean]
+      --reviewer                        Add reviewer to the target PR                        [array]
+      --repoForkOwner                   The owner of the fork where the backport branch is pushed.
+                                        Defaults to the currently authenticated user        [string]
+      --repo                            Repo owner and name                                 [string]
+      --sha, --commit                   Commit sha to backport                              [string]
+      --sourceBranch                    Specify a non-default branch (normally "master") to backport
+                                        from                                                [string]
+      --sourcePRLabel, --sourcePrLabel  Add labels to the source (original) PR               [array]
+  -b, --targetBranch, --branch          Branch(es) to backport to                            [array]
+      --targetBranchChoice              List branches to backport to                         [array]
+  -l, --targetPRLabel, --label          Add labels to the target (backport) PR               [array]
+      --verify                          Opposite of no-verify                              [boolean]
+      --help                            Show help                                          [boolean]
 
-      For bugs, feature requests or questions: https://github.com/sqren/backport/issues
-      Or contact me directly: https://twitter.com/sorenlouv"
-    `);
+For bugs, feature requests or questions: https://github.com/sqren/backport/issues
+Or contact me directly: https://twitter.com/sorenlouv"
+`);
   });
 
   it('lists commits based on .git/config when `repoOwner`/`repoName` is missing', async () => {


### PR DESCRIPTION
Previously if the backport tool encountered conflicts it would allow the user to resolve them manually, or when running in non-interactive mode in CI it would abort.
This PR introduces `commitConflicts: boolean` option. It is disabled by default. When enabled it will commit conflicting files when running on CI.