### PR TITLE
Fix test where CLI output is cutoff at 8192 bytes

### DIFF
--- a/src/options/cliArgs.ts
+++ b/src/options/cliArgs.ts
@@ -413,6 +413,7 @@ export function getOptionsFromCliArgs(processArgs: readonly string[]) {
 
     .alias('version', 'v')
     .help()
+    .exitProcess(!processArgs.includes('--noExitProcess'))
 
     .epilogue(
       'For bugs, feature requests or questions: https://github.com/sqren/backport/issues\nOr contact me directly: https://twitter.com/sorenlouv',

--- a/src/test/e2e/cli/entrypoint.cli.private.test.ts
+++ b/src/test/e2e/cli/entrypoint.cli.private.test.ts
@@ -31,8 +31,13 @@ describe('entrypoint cli', () => {
   });
 
   it('--help', async () => {
-    const { output } = await runBackportViaCli([`--help`, '--noExitProcess']);
-    expect(output).toMatchInlineSnapshot(`
+    const { output } = await runBackportViaCli([`--help`, '--noExitProcess'], {
+      waitForString: 'Or contact me directly',
+    });
+
+    const [help] = output.split('https://twitter.com/sorenlouv');
+
+    expect(help).toMatchInlineSnapshot(`
 "entrypoint.cli.ts [args]
 
 Options:
@@ -120,10 +125,7 @@ Options:
       --help                                          Show help                            [boolean]
 
 For bugs, feature requests or questions: https://github.com/sqren/backport/issues
-Or contact me directly: https://twitter.com/sorenlouv
-Please specify a target branch: "--branch 6.1".
-
-Read more: https://github.com/sqren/backport/blob/main/docs/config-file-options.md#project-config-backportrcjson"
+Or contact me directly: "
 `);
   });
 

--- a/src/test/e2e/cli/entrypoint.cli.private.test.ts
+++ b/src/test/e2e/cli/entrypoint.cli.private.test.ts
@@ -31,9 +31,8 @@ describe('entrypoint cli', () => {
   });
 
   it('--help', async () => {
-    const { output } = await runBackportViaCli([`--help`]);
-    const [help] = output.split('--help');
-    expect(help).toMatchInlineSnapshot(`
+    const { output } = await runBackportViaCli([`--help`, '--noExitProcess']);
+    expect(output).toMatchInlineSnapshot(`
 "entrypoint.cli.ts [args]
 
 Options:
@@ -118,7 +117,13 @@ Options:
       --targetBranchChoice                            List branches to backport to           [array]
   -l, --targetPRLabel, --label                        Add labels to the target (backport) PR [array]
       --verify                                        Opposite of no-verify                [boolean]
-      "
+      --help                                          Show help                            [boolean]
+
+For bugs, feature requests or questions: https://github.com/sqren/backport/issues
+Or contact me directly: https://twitter.com/sorenlouv
+Please specify a target branch: "--branch 6.1".
+
+Read more: https://github.com/sqren/backport/blob/main/docs/config-file-options.md#project-config-backportrcjson"
 `);
   });
 


### PR DESCRIPTION
[yargs](https://github.com/yargs/yargs/blob/main/docs/api.md#exitprocessenable) will call `process.exit` after outputting the help section. When running backport as a child process and reading the output async, the exit command will be called before the full output is written. This can be prevented by calling `.exitProcess(false)`