### PR TITLE
bump axios version

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^19.0.7",
-    "axios": "^1.4.0",
+    "axios": "^1.6.0",
     "dedent": "^0.7.0",
     "del": "^6.1.1",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
Hey @sqren, I see there is a security notification for axios version being used in this repo.

```
An issue discovered in Axios 0.8.1 through 1.5.1 inadvertently reveals the confidential XSRF-TOKEN stored in cookies by including it in the HTTP header X-XSRF-TOKEN for every request made to any host allowing attackers to view sensitive information.
```

Bumping version to lowest patched version. 