### PR TITLE
Fix misleading "auto-resolved" note when conflictResolution is "commit"

### DIFF
--- a/src/lib/cherrypickAndCreateTargetPullRequest/wait-for-cherrypick.ts
+++ b/src/lib/cherrypickAndCreateTargetPullRequest/wait-for-cherrypick.ts
@@ -152,7 +152,10 @@ async function cherrypickAndHandleConflicts({
   if (!options.interactive && options.conflictResolution === 'commit') {
     await gitAddAll({ options });
     await commitChanges({ options, commit, commitAuthor });
-    return { hasCommitsWithConflicts: true, unresolvedFiles: [] };
+    return {
+      hasCommitsWithConflicts: true,
+      unresolvedFiles: conflictingFiles.map((f) => f.relative),
+    };
   }
 
   const conflictingFilesRelative = conflictingFiles

--- a/src/lib/cherrypickAndCreateTargetPullRequest/wait-for-cherrypick.unit.test.ts
+++ b/src/lib/cherrypickAndCreateTargetPullRequest/wait-for-cherrypick.unit.test.ts
@@ -140,3 +140,39 @@ describe('waitForCherrypick with conflictResolution=theirs', () => {
     expect(cherrypickSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('waitForCherrypick with conflictResolution=commit', () => {
+  let cherrypickSpy: MockInstance;
+  let gitAddAllSpy: MockInstance;
+
+  beforeEach(() => {
+    cherrypickSpy = vi.spyOn(git, 'cherrypick');
+    gitAddAllSpy = vi
+      .spyOn(git, 'gitAddAll')
+      .mockResolvedValue({ stderr: '', stdout: '', code: 0, cmdArgs: [] });
+    vi.spyOn(git, 'commitChanges').mockResolvedValue();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should commit conflicts as-is and propagate the file list', async () => {
+    cherrypickSpy.mockResolvedValueOnce(conflictingCherrypickResult);
+
+    const result = await waitForCherrypick(
+      makeOptions({ conflictResolution: 'commit' }),
+      makeCommit(),
+      '7.x',
+    );
+
+    expect(result).toEqual({
+      hasCommitsWithConflicts: true,
+      unresolvedFiles: ['la-liga.md'],
+    });
+
+    expect(gitAddAllSpy).toHaveBeenCalledTimes(1);
+    // No retry — commit mode commits the conflicts directly.
+    expect(cherrypickSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/github/v3/create-pull-request/get-pull-request-body.ts
+++ b/src/lib/github/v3/create-pull-request/get-pull-request-body.ts
@@ -85,15 +85,37 @@ export function getPullRequestBody({
   }
 
   if (hasAnyCommitWithConflicts) {
-    body += getConflictResolutionNote(unresolvedFiles);
+    body += getConflictResolutionNote(
+      options.conflictResolution,
+      unresolvedFiles,
+    );
   }
 
   return body;
 }
 
-function getConflictResolutionNote(unresolvedFiles: string[]): string {
+function getConflictResolutionNote(
+  conflictResolution: ValidConfigOptions['conflictResolution'],
+  unresolvedFiles: string[],
+): string {
+  const header = '\n\n---\n';
+
+  // `commit` mode commits the files with raw conflict markers (`<<<<<<<` /
+  // `=======` / `>>>>>>>`) checked in — nothing is auto-resolved. Saying the
+  // opposite would mislead reviewers into thinking the PR is ready to merge.
+  if (conflictResolution === 'commit') {
+    return (
+      header +
+      '**Note:** This PR was created with conflict markers committed verbatim ' +
+      "to the affected files (`conflictResolution: 'commit'`). " +
+      'The conflicting hunks must be resolved manually before this PR can be merged.'
+    );
+  }
+
+  // `theirs` mode: cherry-pick was retried with `--strategy-option=theirs`,
+  // resolving conflicts in favor of the source commit.
   const base =
-    '\n\n---\n' +
+    header +
     '**Note:** This PR was created with conflicts auto-resolved in favor of the source commit ' +
     '(`--strategy-option=theirs`). Please review the changes carefully.';
 

--- a/src/lib/github/v3/create-pull-request/get-pull-request-body.ts
+++ b/src/lib/github/v3/create-pull-request/get-pull-request-body.ts
@@ -100,34 +100,35 @@ function getConflictResolutionNote(
 ): string {
   const header = '\n\n---\n';
 
-  // `commit` mode commits the files with raw conflict markers (`<<<<<<<` /
-  // `=======` / `>>>>>>>`) checked in — nothing is auto-resolved. Saying the
-  // opposite would mislead reviewers into thinking the PR is ready to merge.
-  if (conflictResolution === 'commit') {
-    return (
-      header +
-      '**Note:** This PR was created with conflict markers committed verbatim ' +
-      "to the affected files (`conflictResolution: 'commit'`). " +
-      'The conflicting hunks must be resolved manually before this PR can be merged.'
-    );
-  }
+  // `commit` mode commits files with raw conflict markers checked in;
+  // `theirs` retries the cherry-pick with --strategy-option=theirs. Both end
+  // up with files the reviewer must look at — same trailer shape, different
+  // base text and file-list label.
+  const { base, fileListLabel } =
+    conflictResolution === 'commit'
+      ? {
+          base:
+            '**Note:** This PR was created with conflict markers committed verbatim ' +
+            "to the affected files (`conflictResolution: 'commit'`). " +
+            'The conflicting hunks must be resolved manually before this PR can be merged.',
+          fileListLabel:
+            'The following files contain committed conflict markers:',
+        }
+      : {
+          base:
+            '**Note:** This PR was created with conflicts auto-resolved in favor of the source commit ' +
+            '(`--strategy-option=theirs`). Please review the changes carefully.',
+          fileListLabel:
+            'The following files still had unresolved conflicts after the retry:',
+        };
 
-  // `theirs` mode: cherry-pick was retried with `--strategy-option=theirs`,
-  // resolving conflicts in favor of the source commit.
-  const base =
-    header +
-    '**Note:** This PR was created with conflicts auto-resolved in favor of the source commit ' +
-    '(`--strategy-option=theirs`). Please review the changes carefully.';
-
+  const note = header + base;
   if (unresolvedFiles.length === 0) {
-    return base;
+    return note;
   }
 
   const fileList = unresolvedFiles.map((f) => `\n - \`${f}\``).join('');
-  return (
-    base +
-    `\n\nThe following files still had unresolved conflicts after the retry:${fileList}`
-  );
+  return note + `\n\n${fileListLabel}${fileList}`;
 }
 
 function stripMarkdownComments(str: string): string {

--- a/src/lib/github/v3/create-pull-request/get-pull-request-body.unit.test.ts
+++ b/src/lib/github/v3/create-pull-request/get-pull-request-body.unit.test.ts
@@ -516,18 +516,19 @@ describe('getPullRequestBody', () => {
   describe('conflict resolution note', () => {
     it('should not append a note when hasAnyCommitWithConflicts is false', () => {
       const body = getPullRequestBody({
-        options: {} as ValidConfigOptions,
+        options: { conflictResolution: 'theirs' } as ValidConfigOptions,
         commits,
         targetBranch: '7.x',
         hasAnyCommitWithConflicts: false,
       });
 
       expect(body).not.toContain('auto-resolved');
+      expect(body).not.toContain('committed verbatim');
     });
 
-    it('should append a note when hasAnyCommitWithConflicts is true', () => {
+    it('should describe the `theirs` strategy when conflictResolution is "theirs"', () => {
       const body = getPullRequestBody({
-        options: {} as ValidConfigOptions,
+        options: { conflictResolution: 'theirs' } as ValidConfigOptions,
         commits,
         targetBranch: '7.x',
         hasAnyCommitWithConflicts: true,
@@ -539,11 +540,12 @@ describe('getPullRequestBody', () => {
       );
       expect(body).toContain('`--strategy-option=theirs`');
       expect(body).not.toContain('still had unresolved conflicts');
+      expect(body).not.toContain('committed verbatim');
     });
 
-    it('should list unresolved files when present', () => {
+    it('should list unresolved files when the `theirs` retry still failed on some files', () => {
       const body = getPullRequestBody({
-        options: {} as ValidConfigOptions,
+        options: { conflictResolution: 'theirs' } as ValidConfigOptions,
         commits,
         targetBranch: '7.x',
         hasAnyCommitWithConflicts: true,
@@ -553,6 +555,23 @@ describe('getPullRequestBody', () => {
       expect(body).toContain('still had unresolved conflicts after the retry');
       expect(body).toContain('`la-liga.md`');
       expect(body).toContain('`premier-league.md`');
+    });
+
+    it('should describe checked-in markers when conflictResolution is "commit"', () => {
+      const body = getPullRequestBody({
+        options: { conflictResolution: 'commit' } as ValidConfigOptions,
+        commits,
+        targetBranch: '7.x',
+        hasAnyCommitWithConflicts: true,
+        unresolvedFiles: [],
+      });
+
+      expect(body).toContain('conflict markers committed verbatim');
+      expect(body).toContain("`conflictResolution: 'commit'`");
+      expect(body).toContain('resolved manually before this PR can be merged');
+      // Must NOT claim auto-resolution — that's the opposite of what happened.
+      expect(body).not.toContain('auto-resolved');
+      expect(body).not.toContain('`--strategy-option=theirs`');
     });
   });
 });

--- a/src/lib/github/v3/create-pull-request/get-pull-request-body.unit.test.ts
+++ b/src/lib/github/v3/create-pull-request/get-pull-request-body.unit.test.ts
@@ -572,6 +572,28 @@ describe('getPullRequestBody', () => {
       // Must NOT claim auto-resolution — that's the opposite of what happened.
       expect(body).not.toContain('auto-resolved');
       expect(body).not.toContain('`--strategy-option=theirs`');
+      // No file list when none provided.
+      expect(body).not.toContain('contain committed conflict markers');
+    });
+
+    it('should list conflicted files when conflictResolution is "commit" and files are provided', () => {
+      const body = getPullRequestBody({
+        options: { conflictResolution: 'commit' } as ValidConfigOptions,
+        commits,
+        targetBranch: '7.x',
+        hasAnyCommitWithConflicts: true,
+        unresolvedFiles: ['la-liga.md', 'premier-league.md'],
+      });
+
+      expect(body).toContain(
+        'The following files contain committed conflict markers:',
+      );
+      expect(body).toContain('`la-liga.md`');
+      expect(body).toContain('`premier-league.md`');
+      // Should not borrow the theirs-mode trailer wording.
+      expect(body).not.toContain(
+        'still had unresolved conflicts after the retry',
+      );
     });
   });
 });


### PR DESCRIPTION
`getPullRequestBody` always appends a note claiming conflicts were "auto-resolved in favor of the source commit (`--strategy-option=theirs`)", but `hasAnyCommitWithConflicts` is also set when `conflictResolution: 'commit'`, where files are committed with raw `<<<<<<<` / `=======` / `>>>>>>>` markers and nothing is resolved. The note describes the opposite outcome and can mislead reviewers into thinking a marker-laden PR is safe to merge.

  ## Problem

  In `wait-for-cherrypick.ts` both branches reach `hasCommitsWithConflicts: true`:

  ```ts
  // theirs — silently resolves to the source side
  return { hasCommitsWithConflicts: true, unresolvedFiles };

  // commit — leaves raw conflict markers in the files
  if (!options.interactive && options.conflictResolution === 'commit') {
    await gitAddAll({ options });
    await commitChanges({ options, commit, commitAuthor });
    return { hasCommitsWithConflicts: true, unresolvedFiles: [] };
  }
  ```

  `getConflictResolutionNote` then prints the `theirs` wording for both.

  ## Fix

  Make the note strategy-aware by passing `options.conflictResolution` into `getConflictResolutionNote`:

  - `'theirs'` keeps the existing wording (including the unresolved-files list when present).
  - `'commit'` gets a new note that names the strategy and says markers were committed verbatim and need manual resolution before merge.

  `'abort'` never reaches this code path (the action throws before creating a PR), and any future strategy falls through to the existing `'theirs'` wording — so no regression.

## Tests

Unit tests were updated. Manually tested as well:

- https://github.com/busec0/backport/pull/4 
- https://github.com/busec0/backport/pull/3