### PR TITLE
Fix wrong sourcePullRequest when commit is contained in another PR's branch (#502)

### DIFF
--- a/src/lib/github/v4/fetchCommits/__snapshots__/fetch-commits-by-author.unit.test.ts.snap
+++ b/src/lib/github/v4/fetchCommits/__snapshots__/fetch-commits-by-author.unit.test.ts.snap
@@ -82,7 +82,7 @@ fragment SourceCommitWithTargetPullRequestFragment on Commit {
     name
     email
   }
-  associatedPullRequests(first: 1) {
+  associatedPullRequests(first: 100) {
     edges {
       node {
         title

--- a/src/lib/github/v4/fetchCommits/__snapshots__/fetch-commits-by-author.unit.test.ts.snap
+++ b/src/lib/github/v4/fetchCommits/__snapshots__/fetch-commits-by-author.unit.test.ts.snap
@@ -82,7 +82,7 @@ fragment SourceCommitWithTargetPullRequestFragment on Commit {
     name
     email
   }
-  associatedPullRequests(first: 100) {
+  associatedPullRequests(first: 20) {
     edges {
       node {
         title

--- a/src/lib/sourceCommit/get-source-pull-request.ts
+++ b/src/lib/sourceCommit/get-source-pull-request.ts
@@ -7,5 +7,13 @@ export type SourcePullRequestNode = NonNullable<
 export function getSourcePullRequest(
   sourceCommit: SourceCommitWithTargetPullRequestFragmentFragment,
 ) {
-  return sourceCommit.associatedPullRequests?.edges?.at(0)?.node;
+  const edges = sourceCommit.associatedPullRequests?.edges ?? [];
+
+  // Pick the PR whose merge produced this commit. GitHub also returns PRs
+  // whose head branch happens to contain it (e.g. rebased open PRs).
+  const merger = edges.find(
+    (edge) => edge?.node?.mergeCommit?.sha === sourceCommit.sha,
+  )?.node;
+
+  return merger ?? edges.at(0)?.node;
 }

--- a/src/lib/sourceCommit/get-source-pull-request.unit.test.ts
+++ b/src/lib/sourceCommit/get-source-pull-request.unit.test.ts
@@ -1,0 +1,89 @@
+import type { SourceCommitWithTargetPullRequestFragmentFragment } from '../../graphql/generated/graphql.js';
+import { getSourcePullRequest } from './get-source-pull-request.js';
+
+/**
+ * Build a minimal sourceCommit shape with the fields getSourcePullRequest reads.
+ * Other fragment fields are not referenced here, so we cast through unknown.
+ */
+function makeSourceCommit(input: {
+  sha: string;
+  pullRequests: Array<{
+    number: number;
+    mergeCommitSha: string | null;
+  }>;
+}): SourceCommitWithTargetPullRequestFragmentFragment {
+  const edges = input.pullRequests.map((pr) => ({
+    node: {
+      number: pr.number,
+      mergeCommit:
+        pr.mergeCommitSha === null
+          ? null
+          : { sha: pr.mergeCommitSha, __typename: 'Commit' },
+    },
+  }));
+  return {
+    sha: input.sha,
+    associatedPullRequests: { edges },
+  } as unknown as SourceCommitWithTargetPullRequestFragmentFragment;
+}
+
+describe('getSourcePullRequest', () => {
+  it('returns undefined when there are no associated PRs', () => {
+    const sourceCommit = makeSourceCommit({
+      sha: 'abc123',
+      pullRequests: [],
+    });
+    expect(getSourcePullRequest(sourceCommit)).toBeUndefined();
+  });
+
+  it('returns the only associated PR when there is just one', () => {
+    const sourceCommit = makeSourceCommit({
+      sha: 'abc123',
+      pullRequests: [{ number: 42, mergeCommitSha: 'abc123' }],
+    });
+    expect(getSourcePullRequest(sourceCommit)?.number).toBe(42);
+  });
+
+  // Regression test for sorenlouv/backport#502.
+  //
+  // GitHub's `associatedPullRequests` returns every PR whose head branch
+  // *contains* the queried commit — including unrelated open PRs that
+  // recently merged the target branch into themselves. With `first: 1` +
+  // `.at(0)`, that wrong PR was returned. The fix picks the PR whose
+  // mergeCommit produced the queried commit.
+  it('picks the PR whose mergeCommit.sha matches the source commit sha', () => {
+    const sourceCommit = makeSourceCommit({
+      sha: 'abc123',
+      pullRequests: [
+        // Open PR whose head happens to contain abc123 (came first from GitHub).
+        { number: 5, mergeCommitSha: null },
+        // The PR that actually merged abc123 into the target branch.
+        { number: 6, mergeCommitSha: 'abc123' },
+      ],
+    });
+    expect(getSourcePullRequest(sourceCommit)?.number).toBe(6);
+  });
+
+  it('falls back to the first PR when no node has a matching mergeCommit (e.g. rebase strategy)', () => {
+    const sourceCommit = makeSourceCommit({
+      sha: 'abc123',
+      pullRequests: [
+        // Rebase-merged PR: per-commit oid (abc123) differs from PR.mergeCommit.sha.
+        { number: 7, mergeCommitSha: 'def456' },
+      ],
+    });
+    expect(getSourcePullRequest(sourceCommit)?.number).toBe(7);
+  });
+
+  it('prefers the merge match over an unrelated first node even when both exist before and after the matcher', () => {
+    const sourceCommit = makeSourceCommit({
+      sha: 'abc123',
+      pullRequests: [
+        { number: 1, mergeCommitSha: 'unrelated1' },
+        { number: 2, mergeCommitSha: 'abc123' },
+        { number: 3, mergeCommitSha: 'unrelated3' },
+      ],
+    });
+    expect(getSourcePullRequest(sourceCommit)?.number).toBe(2);
+  });
+});

--- a/src/lib/sourceCommit/parse-source-commit.ts
+++ b/src/lib/sourceCommit/parse-source-commit.ts
@@ -130,8 +130,9 @@ export const SourceCommitWithTargetPullRequestFragment = graphql(`
       email
     }
 
-    # Source pull request: PR where source commit was merged in
-    associatedPullRequests(first: 1) {
+    # Source pull request: PR where source commit was merged in.
+    # first: 100 disambiguates when multiple PRs' head branches contain the SHA.
+    associatedPullRequests(first: 100) {
       edges {
         node {
           title

--- a/src/lib/sourceCommit/parse-source-commit.ts
+++ b/src/lib/sourceCommit/parse-source-commit.ts
@@ -131,8 +131,8 @@ export const SourceCommitWithTargetPullRequestFragment = graphql(`
     }
 
     # Source pull request: PR where source commit was merged in.
-    # first: 100 disambiguates when multiple PRs' head branches contain the SHA.
-    associatedPullRequests(first: 100) {
+    # first: 20 disambiguates when multiple PRs' head branches contain the SHA.
+    associatedPullRequests(first: 20) {
       edges {
         node {
           title


### PR DESCRIPTION
Closes #502.

## Bug

`associatedPullRequests` on a `Commit` returns every PR whose head branch *contains* the queried SHA, not just the PR that *produced* it via a merge. On an active branch (e.g. a release branch with several open PRs), an unrelated open PR whose head was recently merged/rebased from the target picks up the merge SHA and is returned ahead of the PR that produced it.

`getSourcePullRequest` was reading `.edges.at(0).node`, so the wrong PR was selected as `sourcePullRequest`. Symptoms:

- Wrong labels → `branchLabelMapping` doesn't match → silent `no-branches-exception` (the most common failure mode I've seen).
- Wrong title and PR link in the resulting backport PR body.
- Wrong source for `copySourcePRLabels` / `copySourcePRReviewers`.

I posted a deterministic public repro and full diagnosis in #502.

## Fix

Two-part change in `src/lib/sourceCommit/`:

- `parse-source-commit.ts` — bump `associatedPullRequests(first: 1)` to `(first: 100)` (GitHub's hard cap for connection `first` arguments) so multiple associated PRs are visible to the picker. (`mergeCommit { sha: oid }` was already selected in the fragment.)
- `get-source-pull-request.ts` — prefer the node whose `mergeCommit.sha === sourceCommit.sha` (the PR whose merge produced this exact commit). Fall back to `.at(0)` when no node matches, so behavior is unchanged for commits pushed directly without a PR, and for rebase-merged commits where the per-commit oid differs from `PR.mergeCommit.oid` (already handled by the rebase-strategy code path).

## Tests

- New `get-source-pull-request.unit.test.ts` (5 cases): no PRs, single PR, the regression case (open PR returned first + the actual merging PR returned second), rebase-style fallback, and ordering independence.
- Existing `fetch-commits-by-author` snapshot updated for the `first: 100` query change (only difference).

`npm run test:unit` — 356/356 passing (was 351). `npm run lint` clean.

## Verification against the repro

Public repro on [busec0/backport](https://github.com/busec0/backport): an open PR [busec0/backport#5](https://github.com/busec0/backport/pull/5) contains the merge SHA of the merged PR [busec0/backport#6](https://github.com/busec0/backport/pull/6), both targeting `demo502/release-v1`. Running the CLI:

```bash
node bin/backport --repo busec0/backport --sha c0e9ab819c44ca2c4bd3ff8d22d5b0930c48cd9f \
  --source-branch demo502/release-v1 --target-branch demo502/release-v1 \
  --conflict-resolution commit --no-fork --non-interactive --dry-run
```

Before the fix: `"sourcePullRequest": { "number": 5, "url": "https://github.com/busec0/backport/pull/5", ... }`. After the fix: `"sourcePullRequest": { "number": 6, "url": "https://github.com/busec0/backport/pull/6", ... }`.