### PR TITLE
Migrate private tests from elastic/kibana to backport-org/backport-e2e

### DIFF
--- a/src/entrypoint.module.private.test.ts
+++ b/src/entrypoint.module.private.test.ts
@@ -210,150 +210,102 @@ describe('entrypoint.module', () => {
   });
 
   describe('getCommits', () => {
+    const expectedAppleEmojiCommit: Commit = {
+      author: { name: 'Søren Louv-Jansen', email: 'sorenlouv@gmail.com' },
+      suggestedTargetBranches: [],
+      sourceCommit: {
+        branchLabelMapping: {
+          '^v8.0.0$': 'master',
+          '^v7.9.0$': '7.x',
+          '^v(\\d+).(\\d+).\\d+$': '$1.$2',
+        },
+        committedDate: '2020-08-15T12:40:19Z',
+        message: 'Add 🍏 emoji (#5)',
+        sha: 'ee8c492334cef1ca077a56addb79a26f79821d2f',
+      },
+      sourcePullRequest: {
+        labels: ['v7.8.0', 'v7.9.0', 'v8.0.0'],
+        number: 5,
+        title: 'Add 🍏 emoji',
+        url: 'https://github.com/backport-org/backport-e2e/pull/5',
+        mergeCommit: {
+          message: 'Add 🍏 emoji (#5)',
+          sha: 'ee8c492334cef1ca077a56addb79a26f79821d2f',
+        },
+      },
+      sourceBranch: 'master',
+      targetPullRequestStates: [
+        {
+          branch: '7.8',
+          label: 'v7.8.0',
+          branchLabelMappingKey: String.raw`^v(\d+).(\d+).\d+$`,
+          isSourceBranch: false,
+          state: 'MERGED',
+          number: 7,
+          url: 'https://github.com/backport-org/backport-e2e/pull/7',
+          mergeCommit: {
+            message: 'Add 🍏 emoji (#5) (#7)',
+            sha: '46cd6f9999effdf894a36dbc7db90e890f4be840',
+          },
+        },
+        {
+          branch: '7.x',
+          label: 'v7.9.0',
+          branchLabelMappingKey: '^v7.9.0$',
+          isSourceBranch: false,
+          state: 'MERGED',
+          number: 6,
+          url: 'https://github.com/backport-org/backport-e2e/pull/6',
+          mergeCommit: {
+            message: 'Add 🍏 emoji (#5) (#6)',
+            sha: '4bcd876d4ceaa73cf437bfc89b74d1a4e704c0a6',
+          },
+        },
+        {
+          branch: 'master',
+          label: 'v8.0.0',
+          branchLabelMappingKey: '^v8.0.0$',
+          isSourceBranch: true,
+          state: 'MERGED',
+          number: 5,
+          url: 'https://github.com/backport-org/backport-e2e/pull/5',
+          mergeCommit: {
+            message: 'Add 🍏 emoji (#5)',
+            sha: 'ee8c492334cef1ca077a56addb79a26f79821d2f',
+          },
+        },
+      ],
+    };
+
     it('pullNumber', async () => {
       const commits = await getCommits({
         githubToken: githubToken,
-        repoName: 'kibana',
-        repoOwner: 'elastic',
-        pullNumber: 88_188,
+        repoName: 'backport-e2e',
+        repoOwner: 'backport-org',
+        pullNumber: 5,
       });
 
-      const expectedCommits: Commit[] = [
-        {
-          author: { name: 'Søren Louv-Jansen', email: 'sorenlouv@gmail.com' },
-          suggestedTargetBranches: [],
-          sourceCommit: {
-            branchLabelMapping: {
-              '^v(\\d+).(\\d+).\\d+$': '$1.$2',
-              '^v7.12.0$': '7.x',
-              '^v8.0.0$': 'master',
-            },
-            committedDate: '2021-01-13T20:01:44Z',
-            message:
-              '[APM] Fix incorrect table column header (95th instead of avg) (#88188)',
-            sha: 'd1b348e6213c5ad48653dfaad6eaf4928b2c688b',
-          },
-          sourcePullRequest: {
-            labels: ['Team:APM - DEPRECATED', 'release_note:skip', 'v7.11.0'],
-            number: 88_188,
-            title:
-              '[APM] Fix incorrect table column header (95th instead of avg)',
-            url: 'https://github.com/elastic/kibana/pull/88188',
-            mergeCommit: {
-              message:
-                '[APM] Fix incorrect table column header (95th instead of avg) (#88188)',
-              sha: 'd1b348e6213c5ad48653dfaad6eaf4928b2c688b',
-            },
-          },
-          sourceBranch: 'master',
-          targetPullRequestStates: [
-            {
-              branch: '7.11',
-              isSourceBranch: false,
-              label: 'v7.11.0',
-              branchLabelMappingKey: String.raw`^v(\d+).(\d+).\d+$`,
-              mergeCommit: {
-                message:
-                  '[APM] Fix incorrect table column header (95th instead of avg) (#88188) (#88289)',
-                sha: 'b8194e9ec27d69f485d8b194d1cb5e4f6d8fef6d',
-              },
-              number: 88_289,
-              state: 'MERGED',
-              url: 'https://github.com/elastic/kibana/pull/88289',
-            },
-            {
-              branch: '7.x',
-              mergeCommit: {
-                message:
-                  '[7.x] [APM] Fix incorrect table column header (95th instead of avg) (#88188) (#88288)\n\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>',
-                sha: '52710be7add6811ec4783c7d383d4159c0aa76f5',
-              },
-              number: 88_288,
-              state: 'MERGED',
-              url: 'https://github.com/elastic/kibana/pull/88288',
-            },
-          ],
-        },
-      ];
-      expect(commits).toEqual(expectedCommits);
+      expect(commits).toEqual([expectedAppleEmojiCommit]);
     });
 
     it('sha', async () => {
       const commits = await getCommits({
         githubToken: githubToken,
-        repoName: 'kibana',
-        repoOwner: 'elastic',
-        sha: 'd1b348e6213c5ad48653dfaad6eaf4928b2c688b',
+        repoName: 'backport-e2e',
+        repoOwner: 'backport-org',
+        sha: 'ee8c492334cef1ca077a56addb79a26f79821d2f',
       });
 
-      const expectedCommits: Commit[] = [
-        {
-          author: { name: 'Søren Louv-Jansen', email: 'sorenlouv@gmail.com' },
-          suggestedTargetBranches: [],
-          sourceCommit: {
-            branchLabelMapping: {
-              '^v(\\d+).(\\d+).\\d+$': '$1.$2',
-              '^v7.12.0$': '7.x',
-              '^v8.0.0$': 'master',
-            },
-            committedDate: '2021-01-13T20:01:44Z',
-            message:
-              '[APM] Fix incorrect table column header (95th instead of avg) (#88188)',
-            sha: 'd1b348e6213c5ad48653dfaad6eaf4928b2c688b',
-          },
-          sourcePullRequest: {
-            labels: ['Team:APM - DEPRECATED', 'release_note:skip', 'v7.11.0'],
-            number: 88_188,
-            title:
-              '[APM] Fix incorrect table column header (95th instead of avg)',
-            url: 'https://github.com/elastic/kibana/pull/88188',
-            mergeCommit: {
-              message:
-                '[APM] Fix incorrect table column header (95th instead of avg) (#88188)',
-              sha: 'd1b348e6213c5ad48653dfaad6eaf4928b2c688b',
-            },
-          },
-          sourceBranch: 'master',
-          targetPullRequestStates: [
-            {
-              url: 'https://github.com/elastic/kibana/pull/88289',
-              number: 88_289,
-              branch: '7.11',
-              label: 'v7.11.0',
-              branchLabelMappingKey: String.raw`^v(\d+).(\d+).\d+$`,
-              isSourceBranch: false,
-              state: 'MERGED',
-              mergeCommit: {
-                sha: 'b8194e9ec27d69f485d8b194d1cb5e4f6d8fef6d',
-                message:
-                  '[APM] Fix incorrect table column header (95th instead of avg) (#88188) (#88289)',
-              },
-            },
-            {
-              url: 'https://github.com/elastic/kibana/pull/88288',
-              number: 88_288,
-              branch: '7.x',
-              state: 'MERGED',
-              mergeCommit: {
-                sha: '52710be7add6811ec4783c7d383d4159c0aa76f5',
-                message:
-                  '[7.x] [APM] Fix incorrect table column header (95th instead of avg) (#88188) (#88288)\n\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>',
-              },
-            },
-          ],
-        },
-      ];
-
-      expect(commits).toEqual(expectedCommits);
+      expect(commits).toEqual([expectedAppleEmojiCommit]);
     });
 
     it('prQuery', async () => {
       const commits = await getCommits({
         githubToken: githubToken,
-        repoName: 'kibana',
-        repoOwner: 'elastic',
-        until: '2021-06-02',
-        prQuery: 'label:"Team:APM - DEPRECATED" base:master',
+        repoName: 'backport-e2e',
+        repoOwner: 'backport-org',
+        until: '2021-01-01',
+        prQuery: 'label:v7.9.0 base:master',
         maxCount: 3,
       });
 
@@ -369,21 +321,21 @@ describe('entrypoint.module', () => {
         [
           {
             "branchLabelMapping": undefined,
-            "committedDate": "2021-05-28T12:41:42Z",
-            "message": "[Observability] Fix typo in readme for new navigation (#100861)",
-            "sha": "79945fe0275b2ec9c93747e26154110133ec51fb",
+            "committedDate": "2020-08-15T19:54:32Z",
+            "message": "Change Ulysses to Gretha (conflict) (#8)",
+            "sha": "b484e161b705b39dbbfc5005e67ca24d05b23c37",
           },
           {
             "branchLabelMapping": undefined,
-            "committedDate": "2021-05-28T19:43:30Z",
-            "message": "[APM] Move APM tutorial from apm_oss to x-pack/apm (#100780)",
-            "sha": "0bcd78b0e999feb95057f5e6eafdb572b9b2fe39",
+            "committedDate": "2020-08-15T12:40:19Z",
+            "message": "Add 🍏 emoji (#5)",
+            "sha": "ee8c492334cef1ca077a56addb79a26f79821d2f",
           },
           {
             "branchLabelMapping": undefined,
-            "committedDate": "2021-05-18T10:33:16Z",
-            "message": "Migrate from Joi to @kbn/config-schema in "home" and "features" plugins (#100201)",
-            "sha": "574f6595ad2e5452fa90e6a3111220a599e473c0",
+            "committedDate": "2020-08-15T10:44:04Z",
+            "message": "Add family emoji (#2)",
+            "sha": "59d6ff1ca90a4ce210c0a4f0e159214875c19d60",
           },
         ]
       `);
@@ -392,8 +344,8 @@ describe('entrypoint.module', () => {
     it('author', async () => {
       const commits = await getCommits({
         githubToken: githubToken,
-        repoName: 'kibana',
-        repoOwner: 'elastic',
+        repoName: 'backport-e2e',
+        repoOwner: 'backport-org',
         author: 'sorenlouv',
         until: '2021-01-01T10:00:00Z',
         maxCount: 3,
@@ -410,54 +362,36 @@ describe('entrypoint.module', () => {
             "sourceCommit": {
               "branchLabelMapping": {
                 "^v(\\d+).(\\d+).\\d+$": "$1.$2",
-                "^v7.11.0$": "7.x",
+                "^v7.9.0$": "7.x",
                 "^v8.0.0$": "master",
               },
-              "committedDate": "2020-12-16T15:17:03Z",
-              "message": "[APM] Fix broken link to ML when time range is not set (#85976)",
-              "sha": "744d6809ded7e1055bfda280c351cee3e8c0e3bf",
+              "committedDate": "2020-08-16T21:44:28Z",
+              "message": "Add sheep emoji (#9)",
+              "sha": "eebf165c82a4b718d95c11b3877e365b1949ff28",
             },
             "sourcePullRequest": {
               "labels": [
-                "release_note:fix",
-                "Team:APM - DEPRECATED",
-                "apm:test-plan-done",
-                "v7.11.0",
+                "v7.8.0",
               ],
               "mergeCommit": {
-                "message": "[APM] Fix broken link to ML when time range is not set (#85976)",
-                "sha": "744d6809ded7e1055bfda280c351cee3e8c0e3bf",
+                "message": "Add sheep emoji (#9)",
+                "sha": "eebf165c82a4b718d95c11b3877e365b1949ff28",
               },
-              "number": 85976,
-              "title": "[APM] Fix broken link to ML when time range is not set",
-              "url": "https://github.com/elastic/kibana/pull/85976",
+              "number": 9,
+              "title": "Add sheep emoji",
+              "url": "https://github.com/backport-org/backport-e2e/pull/9",
             },
             "suggestedTargetBranches": [],
             "targetPullRequestStates": [
               {
-                "branch": "7.x",
-                "branchLabelMappingKey": "^v7.11.0$",
+                "branch": "7.8",
+                "branchLabelMappingKey": "^v(\\d+).(\\d+).\\d+$",
                 "isSourceBranch": false,
-                "label": "v7.11.0",
-                "mergeCommit": {
-                  "message": "[APM] Fix broken link to ML when time range is not set (#85976) (#86227)
-
-        Co-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>",
-                  "sha": "2d361f018e0776c237d03b84ca8aa24615d16d99",
-                },
-                "number": 86227,
-                "state": "MERGED",
-                "url": "https://github.com/elastic/kibana/pull/86227",
-              },
-              {
-                "branch": "7.11",
-                "mergeCommit": {
-                  "message": "[APM] Fix broken link to ML when time range is not set (#85976) (#86228)",
-                  "sha": "c6c0015e01601cd852730d5cd20e1a906cbee900",
-                },
-                "number": 86228,
-                "state": "MERGED",
-                "url": "https://github.com/elastic/kibana/pull/86228",
+                "label": "v7.8.0",
+                "mergeCommit": undefined,
+                "number": 10,
+                "state": "OPEN",
+                "url": "https://github.com/backport-org/backport-e2e/pull/10",
               },
             ],
           },
@@ -470,47 +404,49 @@ describe('entrypoint.module', () => {
             "sourceCommit": {
               "branchLabelMapping": {
                 "^v(\\d+).(\\d+).\\d+$": "$1.$2",
-                "^v7.11.0$": "7.x",
+                "^v7.9.0$": "7.x",
                 "^v8.0.0$": "master",
               },
-              "committedDate": "2020-12-15T12:15:00Z",
-              "message": "[APM] Correlations polish (#85116)
-
-        Co-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>",
-              "sha": "20638a64e2a895d4e4a6597d4a37b5db7003f1e9",
+              "committedDate": "2020-08-15T19:54:32Z",
+              "message": "Change Ulysses to Gretha (conflict) (#8)",
+              "sha": "b484e161b705b39dbbfc5005e67ca24d05b23c37",
             },
             "sourcePullRequest": {
               "labels": [
-                "Team:APM - DEPRECATED",
-                "release_note:skip",
-                "v7.11.0",
+                "v7.9.0",
+                "v8.0.0",
               ],
               "mergeCommit": {
-                "message": "[APM] Correlations polish (#85116)
-
-        Co-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>",
-                "sha": "20638a64e2a895d4e4a6597d4a37b5db7003f1e9",
+                "message": "Change Ulysses to Gretha (conflict) (#8)",
+                "sha": "b484e161b705b39dbbfc5005e67ca24d05b23c37",
               },
-              "number": 85116,
-              "title": "[APM] Correlations polish",
-              "url": "https://github.com/elastic/kibana/pull/85116",
+              "number": 8,
+              "title": "Change Ulysses to Gretha (conflict)",
+              "url": "https://github.com/backport-org/backport-e2e/pull/8",
             },
-            "suggestedTargetBranches": [],
+            "suggestedTargetBranches": [
+              "7.x",
+            ],
             "targetPullRequestStates": [
               {
                 "branch": "7.x",
-                "branchLabelMappingKey": "^v7.11.0$",
+                "branchLabelMappingKey": "^v7.9.0$",
                 "isSourceBranch": false,
-                "label": "v7.11.0",
+                "label": "v7.9.0",
+                "state": "NOT_CREATED",
+              },
+              {
+                "branch": "master",
+                "branchLabelMappingKey": "^v8.0.0$",
+                "isSourceBranch": true,
+                "label": "v8.0.0",
                 "mergeCommit": {
-                  "message": "[7.x] [APM] Correlations polish (#85116) (#85940)
-
-        Co-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>",
-                  "sha": "42b3ecb40c344cd57800b8fa387ae32bad24bfc4",
+                  "message": "Change Ulysses to Gretha (conflict) (#8)",
+                  "sha": "b484e161b705b39dbbfc5005e67ca24d05b23c37",
                 },
-                "number": 85940,
+                "number": 8,
                 "state": "MERGED",
-                "url": "https://github.com/elastic/kibana/pull/85940",
+                "url": "https://github.com/backport-org/backport-e2e/pull/8",
               },
             ],
           },
@@ -523,41 +459,67 @@ describe('entrypoint.module', () => {
             "sourceCommit": {
               "branchLabelMapping": {
                 "^v(\\d+).(\\d+).\\d+$": "$1.$2",
-                "^v7.11.0$": "7.x",
+                "^v7.9.0$": "7.x",
                 "^v8.0.0$": "master",
               },
-              "committedDate": "2020-12-07T14:43:58Z",
-              "message": "[APM] Improve pointer event hook (#85117)",
-              "sha": "cee681afb3c5f87371112fab9a7e5dddbafea0a8",
+              "committedDate": "2020-08-15T12:40:19Z",
+              "message": "Add 🍏 emoji (#5)",
+              "sha": "ee8c492334cef1ca077a56addb79a26f79821d2f",
             },
             "sourcePullRequest": {
               "labels": [
-                "Team:APM - DEPRECATED",
-                "release_note:skip",
-                "v7.11.0",
+                "v7.8.0",
+                "v7.9.0",
+                "v8.0.0",
               ],
               "mergeCommit": {
-                "message": "[APM] Improve pointer event hook (#85117)",
-                "sha": "cee681afb3c5f87371112fab9a7e5dddbafea0a8",
+                "message": "Add 🍏 emoji (#5)",
+                "sha": "ee8c492334cef1ca077a56addb79a26f79821d2f",
               },
-              "number": 85117,
-              "title": "[APM] Improve pointer event hook",
-              "url": "https://github.com/elastic/kibana/pull/85117",
+              "number": 5,
+              "title": "Add 🍏 emoji",
+              "url": "https://github.com/backport-org/backport-e2e/pull/5",
             },
             "suggestedTargetBranches": [],
             "targetPullRequestStates": [
               {
-                "branch": "7.x",
-                "branchLabelMappingKey": "^v7.11.0$",
+                "branch": "7.8",
+                "branchLabelMappingKey": "^v(\\d+).(\\d+).\\d+$",
                 "isSourceBranch": false,
-                "label": "v7.11.0",
+                "label": "v7.8.0",
                 "mergeCommit": {
-                  "message": "[7.x] [APM] Improve pointer event hook (#85117) (#85142)",
-                  "sha": "3b72a4f3cc7c0abd0541073e1d0246b85cea3def",
+                  "message": "Add 🍏 emoji (#5) (#7)",
+                  "sha": "46cd6f9999effdf894a36dbc7db90e890f4be840",
                 },
-                "number": 85142,
+                "number": 7,
                 "state": "MERGED",
-                "url": "https://github.com/elastic/kibana/pull/85142",
+                "url": "https://github.com/backport-org/backport-e2e/pull/7",
+              },
+              {
+                "branch": "7.x",
+                "branchLabelMappingKey": "^v7.9.0$",
+                "isSourceBranch": false,
+                "label": "v7.9.0",
+                "mergeCommit": {
+                  "message": "Add 🍏 emoji (#5) (#6)",
+                  "sha": "4bcd876d4ceaa73cf437bfc89b74d1a4e704c0a6",
+                },
+                "number": 6,
+                "state": "MERGED",
+                "url": "https://github.com/backport-org/backport-e2e/pull/6",
+              },
+              {
+                "branch": "master",
+                "branchLabelMappingKey": "^v8.0.0$",
+                "isSourceBranch": true,
+                "label": "v8.0.0",
+                "mergeCommit": {
+                  "message": "Add 🍏 emoji (#5)",
+                  "sha": "ee8c492334cef1ca077a56addb79a26f79821d2f",
+                },
+                "number": 5,
+                "state": "MERGED",
+                "url": "https://github.com/backport-org/backport-e2e/pull/5",
               },
             ],
           },
@@ -569,8 +531,8 @@ describe('entrypoint.module', () => {
       await expect(() =>
         getCommits({
           githubToken: githubToken,
-          repoName: 'kibana',
-          repoOwner: 'elastic',
+          repoName: 'backport-e2e',
+          repoOwner: 'backport-org',
           maxCount: 3,
         }),
       ).rejects.toThrow(

--- a/src/lib/github/v4/fetchCommits/all-fetchers.private.test.ts
+++ b/src/lib/github/v4/fetchCommits/all-fetchers.private.test.ts
@@ -16,11 +16,11 @@ describe('allFetchers', () => {
       githubToken,
       author: 'sorenlouv',
       maxCount: 1,
-      repoName: 'kibana',
-      repoOwner: 'elastic',
-      sourceBranch: 'main',
-      since: '2021-01-10T00:00:00Z',
-      until: '2022-01-01T00:00:00Z',
+      repoName: 'backport-e2e',
+      repoOwner: 'backport-org',
+      sourceBranch: 'master',
+      since: '2020-08-16T00:00:00Z',
+      until: '2020-08-17T00:00:00Z',
       commitPaths: [] as Array<string>,
     });
 
@@ -33,8 +33,8 @@ describe('allFetchers', () => {
     }
 
     const commitByPullNumber = await fetchCommitsByPullNumber({
-      repoOwner: 'elastic',
-      repoName: 'kibana',
+      repoOwner: 'backport-org',
+      repoName: 'backport-e2e',
       githubToken,
       pullNumber: commitByAuthor.sourcePullRequest.number,
       sourceBranch: 'master',
@@ -45,11 +45,11 @@ describe('allFetchers', () => {
 
   it('matches commitByAuthor with commitBySha', async () => {
     const commitBySha = await fetchCommitBySha({
-      repoOwner: 'elastic',
-      repoName: 'kibana',
+      repoOwner: 'backport-org',
+      repoName: 'backport-e2e',
       githubToken,
       sha: commitByAuthor.sourceCommit.sha,
-      sourceBranch: 'main',
+      sourceBranch: 'master',
     });
 
     expect(commitByAuthor).toEqual(commitBySha);
@@ -62,10 +62,10 @@ describe('allFetchers', () => {
       since: null,
       until: null,
       maxCount: 1,
-      prQuery: `created:2021-12-20..2021-12-20`,
-      repoName: 'kibana',
-      repoOwner: 'elastic',
-      sourceBranch: 'main',
+      prQuery: `created:2020-08-16..2020-08-16`,
+      repoName: 'backport-e2e',
+      repoOwner: 'backport-org',
+      sourceBranch: 'master',
     });
 
     const commitBySearchQuery = commitsBySearchQuery[0];
@@ -75,61 +75,38 @@ describe('allFetchers', () => {
 
   it('returns correct response for commitByAuthor', () => {
     const expectedCommit: Commit = {
-      author: { email: 'soren.louv@elastic.co', name: 'Søren Louv-Jansen' },
+      author: { email: 'sorenlouv@gmail.com', name: 'Søren Louv-Jansen' },
       suggestedTargetBranches: [],
       sourceCommit: {
         branchLabelMapping: {
+          '^v8.0.0$': 'master',
+          '^v7.9.0$': '7.x',
           '^v(\\d+).(\\d+).\\d+$': '$1.$2',
-          '^v8.1.0$': 'main',
         },
-        committedDate: '2021-12-20T14:20:16Z',
-        message: '[APM] Add note about synthtrace to APM docs (#121633)',
-        sha: 'd421ddcf6157150596581c7885afa3690cec6339',
+        committedDate: '2020-08-16T21:44:28Z',
+        message: 'Add sheep emoji (#9)',
+        sha: 'eebf165c82a4b718d95c11b3877e365b1949ff28',
       },
       sourcePullRequest: {
-        labels: [
-          'Team:APM - DEPRECATED',
-          'v8.0.0',
-          'release_note:skip',
-          'auto-backport',
-          'v8.1.0',
-        ],
-        number: 121_633,
-        title: '[APM] Add note about synthtrace to APM docs',
-        url: 'https://github.com/elastic/kibana/pull/121633',
+        labels: ['v7.8.0'],
+        number: 9,
+        title: 'Add sheep emoji',
+        url: 'https://github.com/backport-org/backport-e2e/pull/9',
         mergeCommit: {
-          message: '[APM] Add note about synthtrace to APM docs (#121633)',
-          sha: 'd421ddcf6157150596581c7885afa3690cec6339',
+          message: 'Add sheep emoji (#9)',
+          sha: 'eebf165c82a4b718d95c11b3877e365b1949ff28',
         },
       },
-      sourceBranch: 'main',
+      sourceBranch: 'master',
       targetPullRequestStates: [
         {
-          branch: '8.0',
-          label: 'v8.0.0',
+          branch: '7.8',
+          label: 'v7.8.0',
           branchLabelMappingKey: String.raw`^v(\d+).(\d+).\d+$`,
           isSourceBranch: false,
-          mergeCommit: {
-            message:
-              '[APM] Add note about synthtrace to APM docs (#121633) (#121643)\n\nCo-authored-by: Søren Louv-Jansen <soren.louv@elastic.co>',
-            sha: '842adfdeb5541b059231857522f9009771a46107',
-          },
-          number: 121_643,
-          state: 'MERGED',
-          url: 'https://github.com/elastic/kibana/pull/121643',
-        },
-        {
-          branch: 'main',
-          label: 'v8.1.0',
-          branchLabelMappingKey: '^v8.1.0$',
-          isSourceBranch: true,
-          mergeCommit: {
-            message: '[APM] Add note about synthtrace to APM docs (#121633)',
-            sha: 'd421ddcf6157150596581c7885afa3690cec6339',
-          },
-          number: 121_633,
-          state: 'MERGED',
-          url: 'https://github.com/elastic/kibana/pull/121633',
+          state: 'OPEN',
+          number: 10,
+          url: 'https://github.com/backport-org/backport-e2e/pull/10',
         },
       ],
     };

--- a/src/lib/github/v4/fetchCommits/fetch-commit-by-sha.private.test.ts
+++ b/src/lib/github/v4/fetchCommits/fetch-commit-by-sha.private.test.ts
@@ -11,47 +11,73 @@ describe('fetchCommitBySha', () => {
       suggestedTargetBranches: [],
       sourceCommit: {
         branchLabelMapping: {
-          '^v(\\d+).(\\d+).\\d+$': '$1.$2',
-          '^v7.9.0$': '7.x',
           '^v8.0.0$': 'master',
+          '^v7.9.0$': '7.x',
+          '^v(\\d+).(\\d+).\\d+$': '$1.$2',
         },
-        committedDate: '2020-07-07T20:40:28Z',
-        message: '[APM] Add API tests (#70740)',
-        sha: 'cb6fbc0e1b406675724181a3e9f59459b5f8f892',
+        committedDate: '2020-08-15T12:40:19Z',
+        message: 'Add 🍏 emoji (#5)',
+        sha: 'ee8c492334cef1ca077a56addb79a26f79821d2f',
       },
       sourcePullRequest: {
-        labels: ['Team:APM - DEPRECATED', 'release_note:skip', 'v7.9.0'],
-        number: 70_740,
-        title: '[APM] Add API tests',
-        url: 'https://github.com/elastic/kibana/pull/70740',
+        labels: ['v7.8.0', 'v7.9.0', 'v8.0.0'],
+        number: 5,
+        title: 'Add 🍏 emoji',
+        url: 'https://github.com/backport-org/backport-e2e/pull/5',
         mergeCommit: {
-          message: '[APM] Add API tests (#70740)',
-          sha: 'cb6fbc0e1b406675724181a3e9f59459b5f8f892',
+          message: 'Add 🍏 emoji (#5)',
+          sha: 'ee8c492334cef1ca077a56addb79a26f79821d2f',
         },
       },
       sourceBranch: 'master',
       targetPullRequestStates: [
+        {
+          branch: '7.8',
+          label: 'v7.8.0',
+          branchLabelMappingKey: String.raw`^v(\d+).(\d+).\d+$`,
+          isSourceBranch: false,
+          state: 'MERGED',
+          number: 7,
+          url: 'https://github.com/backport-org/backport-e2e/pull/7',
+          mergeCommit: {
+            message: 'Add 🍏 emoji (#5) (#7)',
+            sha: '46cd6f9999effdf894a36dbc7db90e890f4be840',
+          },
+        },
         {
           branch: '7.x',
           label: 'v7.9.0',
           branchLabelMappingKey: '^v7.9.0$',
           isSourceBranch: false,
           state: 'MERGED',
-          number: 71_014,
-          url: 'https://github.com/elastic/kibana/pull/71014',
+          number: 6,
+          url: 'https://github.com/backport-org/backport-e2e/pull/6',
           mergeCommit: {
-            message: '[APM] Add API tests (#70740) (#71014)',
-            sha: 'd15242be682582e58cd69f6b7707565434e99293',
+            message: 'Add 🍏 emoji (#5) (#6)',
+            sha: '4bcd876d4ceaa73cf437bfc89b74d1a4e704c0a6',
+          },
+        },
+        {
+          branch: 'master',
+          label: 'v8.0.0',
+          branchLabelMappingKey: '^v8.0.0$',
+          isSourceBranch: true,
+          state: 'MERGED',
+          number: 5,
+          url: 'https://github.com/backport-org/backport-e2e/pull/5',
+          mergeCommit: {
+            message: 'Add 🍏 emoji (#5)',
+            sha: 'ee8c492334cef1ca077a56addb79a26f79821d2f',
           },
         },
       ],
     };
 
     const commit = await fetchCommitBySha({
-      repoOwner: 'elastic',
-      repoName: 'kibana',
+      repoOwner: 'backport-org',
+      repoName: 'backport-e2e',
       githubToken,
-      sha: 'cb6fbc0e',
+      sha: 'ee8c4923',
       sourceBranch: 'master',
     });
 
@@ -61,26 +87,26 @@ describe('fetchCommitBySha', () => {
   it('throws if sha does not exist', async () => {
     await expect(
       fetchCommitBySha({
-        repoOwner: 'elastic',
-        repoName: 'kibana',
+        repoOwner: 'backport-org',
+        repoName: 'backport-e2e',
         githubToken,
         sha: 'fc22f59',
-        sourceBranch: 'main',
+        sourceBranch: 'master',
       }),
-    ).rejects.toThrow('No commit found on branch "main" with sha "fc22f59"');
+    ).rejects.toThrow('No commit found on branch "master" with sha "fc22f59"');
   });
 
   it('throws if sha is invalid', async () => {
     await expect(
       fetchCommitBySha({
-        repoOwner: 'elastic',
-        repoName: 'kibana',
+        repoOwner: 'backport-org',
+        repoName: 'backport-e2e',
         githubToken,
         sha: 'myCommitSha',
-        sourceBranch: 'main',
+        sourceBranch: 'master',
       }),
     ).rejects.toThrow(
-      'No commit found on branch "main" with sha "myCommitSha"',
+      'No commit found on branch "master" with sha "myCommitSha"',
     );
   });
 });

--- a/src/lib/github/v4/get-repo-owner-and-name-from-git-remotes.private.test.ts
+++ b/src/lib/github/v4/get-repo-owner-and-name-from-git-remotes.private.test.ts
@@ -13,7 +13,7 @@ describe('fetchRemoteProjectConfig', () => {
       const execOpts = { cwd: sandboxPath };
       await exec(`git init`, execOpts);
       await exec(
-        `git remote add sorenlouv git@github.com:sorenlouv/kibana.git`,
+        `git remote add sorenlouv git@github.com:sorenlouv/backport-e2e.git`,
         execOpts,
       );
 
@@ -23,8 +23,8 @@ describe('fetchRemoteProjectConfig', () => {
           cwd: sandboxPath,
         }),
       ).toEqual({
-        repoName: 'kibana',
-        repoOwner: 'elastic',
+        repoName: 'backport-e2e',
+        repoOwner: 'backport-org',
       });
     });
   });

--- a/src/test/cli/binary.private.test.ts
+++ b/src/test/cli/binary.private.test.ts
@@ -42,7 +42,7 @@ describe('CLI "backport" binary', () => {
       [
         binPath,
         '--repo',
-        'elastic/kibana',
+        'backport-org/backport-e2e',
         `--github-token`,
         githubToken,
         `--dir=${sandboxPath}`,
@@ -53,7 +53,7 @@ describe('CLI "backport" binary', () => {
     );
 
     const strippedStdout = stripAnsi(result.stdout);
-    expect(strippedStdout).toContain('repo: elastic/kibana');
+    expect(strippedStdout).toContain('repo: backport-org/backport-e2e');
     expect(strippedStdout).toContain('Select commit');
   });
 

--- a/src/test/cli/date-filters.private.test.ts
+++ b/src/test/cli/date-filters.private.test.ts
@@ -33,10 +33,10 @@ describe('date filters (since, until)', () => {
   it('combined with --pr-query', async () => {
     const options = [
       '--branch=7.x',
-      '--repo=elastic/kibana',
+      '--repo=backport-org/backport-e2e',
       `--github-token=${githubToken}`,
-      '--since=2023-09-01',
-      '--until=2023-10-01',
+      '--since=2020-08-15',
+      '--until=2020-08-17',
     ];
 
     const { output: outputWithoutPrQuery } = await runBackportViaCli(options, {
@@ -44,28 +44,34 @@ describe('date filters (since, until)', () => {
     });
 
     expect(outputWithoutPrQuery).toMatchInlineSnapshot(`
-      "repo: elastic/kibana | sourceBranch: main | author: sorenlouv | autoMerge: true | since: 2023-09-01T00:00:00.000Z | until: 2023-10-01T00:00:00.000Z
+      "repo: backport-org/backport-e2e | sourceBranch: master | author: sorenlouv | since: 2020-08-15T00:00:00.000Z | until: 2020-08-17T00:00:00.000Z
 
       ? Select commit
-      ❯ 1. [APM] Add support for versioned APIs in diagnostics tool (#167050)
-        2. [APM] Add permissions for "input-only" package (#166234)
-        3. [APM] Add docs for Serverless API tests (#166147)
-        4. [APM] Paginate big traces (#165584) 8.10
-        5. [APM] Move index settings persistence to data access plugn (#165560)
+      ❯ 1. Add sheep emoji (#9) 7.8
+        2. Change Ulysses to Gretha (conflict) (#8) 7.x
+        3. Add 🍏 emoji (#5) 7.8, 7.x
+        4. Add family emoji (#2) 7.x
+        5. Add \`backport\` dep
+        6. Merge pull request #1 from backport-org/add-heart-emoji
+        7. Add ❤️ emoji
+        8. Update .backportrc.json
+        9. Bump to 8.0.0
+        10.Add package.json
 
       ↑↓ navigate • ⏎ select"
     `);
 
     const { output: outputWithPrQuery } = await runBackportViaCli(
-      [...options, `--pr-query="label:release_note:fix"`],
+      [...options, `--pr-query="label:v7.8.0"`],
       { waitForString: 'Select commit' },
     );
 
     expect(outputWithPrQuery).toMatchInlineSnapshot(`
-      "repo: elastic/kibana | sourceBranch: main | author: sorenlouv | autoMerge: true | since: 2023-09-01T00:00:00.000Z | until: 2023-10-01T00:00:00.000Z
+      "repo: backport-org/backport-e2e | sourceBranch: master | author: sorenlouv | since: 2020-08-15T00:00:00.000Z | until: 2020-08-17T00:00:00.000Z
 
       ? Select commit
-      ❯ 1. [APM] Paginate big traces (#165584) 8.10
+      ❯ 1. Add sheep emoji (#9) 7.8
+        2. Add 🍏 emoji (#5) 7.8, 7.x
 
       ↑↓ navigate • ⏎ select"
     `);


### PR DESCRIPTION
## Problem

Several private tests were failing on `main` due to drift in live `elastic/kibana` data the tests asserted on. The root cause was not PR labels but two account-lifecycle events:

1. **`soren.louv@elastic.co` is no longer associated with the `sorenlouv` GitHub account** (verified: the commit author resolves to `user: null`). GitHub matches commits to users via the emails currently registered on the account, so `history(author: {id})` and `author:sorenlouv` searches silently stopped returning every elastic.co-authored commit. This broke `all-fetchers.private.test.ts` (the anchor commit vanished from author history) and `date-filters.private.test.ts` (the Sept 2023 window contains only elastic.co-authored commits → "There are no commits by sorenlouv").
2. **The `sorenlouv/kibana` fork was deleted** (404), breaking the fork-parent resolution test in `get-repo-owner-and-name-from-git-remotes.private.test.ts`.

## Fix

Rather than re-pinning to newer kibana data (which would drift again), every network-dependent kibana assertion now targets `backport-org/backport-e2e`, whose history is frozen by convention:

- **all-fetchers**: anchored on PR #9 ("Add sheep emoji") — its permanently-open backport PR #10 provides `OPEN` state coverage in `targetPullRequestStates`.
- **entrypoint.module `getCommits` + fetch-commit-by-sha**: anchored on PR #5 ("Add 🍏 emoji") — three version labels and two merged backport PRs (#6 → `7.x`, #7 → `7.8`) preserve the rich `MERGED`/`isSourceBranch` coverage of the old kibana goldens. The previously duplicated ~70-line goldens in the `pullNumber`/`sha` tests are now one shared constant.
- **date-filters `--pr-query`**: filters on `label:v7.8.0` (a label backport-org controls) instead of kibana's `release_note:fix`.
- **fork resolution**: uses the `sorenlouv/backport-e2e` fork → resolves to `backport-org/backport-e2e`.
- **binary CLI smoke test**: lists backport-e2e commits.

The only remaining `elastic/kibana` strings in non-unit tests are offline remote-URL fixtures in `git.private.test.ts` (API pointed at localhost, no network calls).

## Notes for review

- This eliminates the test suite's last network dependency on repos outside `backport-org` control, except the `sorenlouv/backport-e2e` fork (a fork structurally cannot live in the parent's org).
- Lost incidental coverage: the old date-filters snapshot exercised kibana's remote-config `autoMerge: true`; remote-config behavior is covered by the dedicated fixture-repo tests.
- Verified: full private suite passes — 27 files, 151 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)