### PR TITLE
ci: run offline tests on fork PRs, gate private tests, add nightly live-test run

### DIFF
--- a/.github/workflows/run-lint-and-tests.yml
+++ b/.github/workflows/run-lint-and-tests.yml
@@ -11,9 +11,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Nightly run of the live (credentialed) test suites at 03:00 UTC
+    - cron: '0 3 * * *'
 
 jobs:
-  lint-and-test:
+  # Offline checks: run for every trigger, including fork PRs (no secrets needed)
+  lint-and-unit:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -32,4 +36,50 @@ jobs:
       - run: npm run build
       - run: npm run lint
       - run: npm run test:unit
+      - run: npm run test:integration
+
+  # Credentialed tests: skipped on fork PRs (GitHub does not expose secrets to
+  # pull_request events from forks) and on the nightly schedule (covered by
+  # nightly-live-tests below)
+  private-tests:
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: git config --global user.email "backportci@users.noreply.github.com "
+      - run: git config --global user.name "Backport CI"
+      - run: npm ci
+      - run: npm run build
       - run: GITHUB_TOKEN=${{ secrets.GH_ACCESS_TOKEN }} npm run test:private
+
+  # Drift canary: nightly run of all live suites against real GitHub data, so
+  # upstream changes to fixtures surface even when no commits are landing
+  nightly-live-tests:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: git config --global user.email "backportci@users.noreply.github.com "
+      - run: git config --global user.name "Backport CI"
+      - run: npm ci
+      - run: npm run build
+      - run: GITHUB_TOKEN=${{ secrets.GH_ACCESS_TOKEN }} npm run test:private
+      - run: GITHUB_TOKEN=${{ secrets.GH_ACCESS_TOKEN }} npm run test:mutation

--- a/.github/workflows/run-lint-and-tests.yml
+++ b/.github/workflows/run-lint-and-tests.yml
@@ -17,6 +17,11 @@ on:
 
 jobs:
   # Offline checks: run for every trigger, including fork PRs (no secrets needed)
+  #
+  # NOTE: this job was renamed from "lint-and-test". Branch protection on main
+  # requires the status check context "lint-and-test (22.x)" — when merging this
+  # change, update the required check to "lint-and-unit (22.x)" or every PR will
+  # hang on the orphaned "Expected — lint-and-test (22.x)" check.
   lint-and-unit:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Problem

GitHub never exposes repository secrets to `pull_request` events from forks. The single `lint-and-test` job ended with `GITHUB_TOKEN=${{ secrets.GH_ACCESS_TOKEN }} npm run test:private`, so on every outside contributor's PR the token was empty, all 27 private test files threw, and CI was permanently red for forks. Meanwhile `test:integration` and `test:mutation` ran in no workflow at all, so they silently rotted.

## New job structure

| Job | When it runs | What it runs |
| --- | --- | --- |
| `lint-and-unit` | every trigger (incl. fork PRs) | `npm ci`, build, lint, `test:unit`, `test:integration` |
| `private-tests` | push to main, same-repo PRs, `workflow_dispatch` — **skipped** on fork PRs and on schedule | `npm ci`, build, `test:private` with `GH_ACCESS_TOKEN` |
| `nightly-live-tests` | nightly cron (`0 3 * * *`) | `npm ci`, build, `test:private` + `test:mutation` with `GH_ACCESS_TOKEN` |

Details:

- `lint-and-unit` needs zero credentials: `test:integration` packs the npm tarball and installs it in a temp dir (registry network only), and the build step runs first since the tarball needs `dist/`.
- `private-tests` is gated with `github.event_name != 'schedule' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)`, so fork PRs show the job as *skipped* rather than failed. The git config + build steps are kept because the private tests clone repos/commit and `binary.private.test.ts` requires `dist/`.
- `nightly-live-tests` doubles as a **drift canary**: the private and mutation suites assert against live GitHub data (repos, PRs, commits in backport-org fixtures), so a nightly run surfaces upstream changes to that fixture data even during quiet periods with no commits.
- `workflow_dispatch` and Node 22 are unchanged.

## ⚠️ Merge prerequisite: update the required status check

Branch protection on `main` currently requires the status check context **`lint-and-test (22.x)`** (with `enforce_admins` off). Renaming the job to `lint-and-unit` means no job will ever report that context again, so after merging, every PR would hang on "Expected — lint-and-test (22.x)". **When merging this PR, update the required check context to `lint-and-unit (22.x)`**, e.g.:

```sh
gh api -X PATCH repos/sorenlouv/backport/branches/main/protection/required_status_checks \
  -f "checks[][context]=lint-and-unit (22.x)" -F "checks[][app_id]=15368"
```

Optionally also require `private-tests (22.x)` — skipped jobs (fork PRs) still satisfy required checks, so this won't block outside contributors. Note this PR itself shows as `BLOCKED` until the context is updated, for exactly this reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
