### PR TITLE
docs: contributor onboarding, CI expectations, PR/issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
       description: >-
         Relevant contents of `.backportrc.json` (project config) and/or
         `~/.backport/config.json` (global config). **Replace your
-        `accessToken` with REDACTED before posting.**
+        `githubToken` with REDACTED before posting.**
       render: json
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Report a problem with the backport CLI
+labels: ['bug']
+body:
+  - type: input
+    id: backport-version
+    attributes:
+      label: Backport version
+      description: Output of `backport --version`
+      placeholder: '12.0.0'
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: Output of `node --version`
+      placeholder: 'v22.0.0'
+    validations:
+      required: true
+
+  - type: input
+    id: command
+    attributes:
+      label: Command
+      description: The exact command you ran
+      placeholder: 'backport --branch 8.x --pr 1234'
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: >-
+        Relevant contents of `.backportrc.json` (project config) and/or
+        `~/.backport/config.json` (global config). **Replace your
+        `accessToken` with REDACTED before posting.**
+      render: json
+    validations:
+      required: false
+
+  - type: textarea
+    id: verbose-output
+    attributes:
+      label: Output with --verbose
+      description: >-
+        Re-run the command with the `--verbose` flag and paste the output.
+        Double-check that no access token appears in the output.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-vs-actual
+    attributes:
+      label: Expected vs actual behavior
+      description: What did you expect to happen, and what happened instead?
+      placeholder: |
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Checklist
+
+- [ ] `npm run test:unit` passes
+- [ ] Ran `npm run codegen` if any `graphql()` tagged template changed
+- [ ] Updated `docs/` if options or CLI flags changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,23 @@
 # Contributing
 
+## Getting started
+
+```
+git clone https://github.com/sorenlouv/backport.git
+cd backport
+npm install
+npm run build
+```
+
+- **Node.js >= 22 is required** (see `engines` in `package.json`).
+- **`npm run build` is not optional**: it runs the GraphQL codegen which generates TypeScript types into `src/graphql/generated/`. That directory is gitignored, so nothing compiles (tsc, eslint, vitest) until the build has run at least once. `npm install` triggers it automatically via the `prepare` script, but if compilation suddenly fails after a fresh clone or a clean, run `npm run build`.
+- **Optional:** create a `.env` file in the repo root with a `GITHUB_TOKEN=ghp_xxx` entry if you want to run the live test tiers (see [Test tiers](#test-tiers) below). It is gitignored and only needed for the private/mutation tests — unit tests run without any credentials.
+
+## What CI runs on your PR
+
+- **Every PR**: lint, unit tests, and integration tests. These are fully offline/mocked and require no credentials — they must pass for your PR to be merged.
+- **Credentialed live suites** (`test:private` and `test:mutation`): these talk to real GitHub repos and require repository secrets, so they only run for branches pushed to the main repository and on a nightly schedule. If you open a PR from a fork, that job will show as **skipped** — this is expected and fine; a maintainer's nightly run covers it.
+
 ### Run
 
 ```


### PR DESCRIPTION
## Summary

Contributor-facing docs and GitHub templates:

- **CONTRIBUTING.md** — two new sections at the top:
  - *Getting started*: clone, Node >= 22 (matches `engines`), `npm install` + `npm run build`, and an explanation of why the build is mandatory (`src/graphql/generated/` is gitignored, so tsc/eslint/vitest fail until codegen has run). Also documents the optional `.env` with `GITHUB_TOKEN` for the live test tiers.
  - *What CI runs on your PR*: lint + unit + integration run on every PR; the credentialed live suites (private/mutation) only run for branches on the main repo and on a nightly schedule, so fork PRs show that job as skipped — expected and fine.
- **.github/PULL_REQUEST_TEMPLATE.md** — Summary section plus a checklist: unit tests pass, `npm run codegen` re-run if any `graphql()` tagged template changed, `docs/` updated if options/CLI flags changed.
- **.github/ISSUE_TEMPLATE/bug_report.yml** — issue form asking for backport version, Node version, exact command, relevant config (with token REDACTED), `--verbose` output, and expected vs actual behavior. Auto-labels with `bug`.
- **.github/ISSUE_TEMPLATE/config.yml** — `blank_issues_enabled: true`, so questions/feature requests aren't forced through the bug form.

## Merge ordering

The "What CI runs on your PR" section describes the CI layout introduced by the `improve/ci-fork-prs` PR (integration tests on every PR; private/mutation gated to main-repo branches + nightly). This PR should merge **after** that one, or the section can be trivially amended if the CI layout lands differently.

The existing "Testing" section in CONTRIBUTING.md was intentionally left untouched — a sibling PR owns its rewrite.

## Verification

- `python3` + `yaml.safe_load` on both ISSUE_TEMPLATE files, plus issue-form schema checks (top-level `name`/`description`/`body`; each non-markdown body item has `id` and `attributes.label`; unique ids; `required` flags where appropriate).
- Markdown read back and renders sensibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)