### PR TITLE
refactor: break circular imports of the public entrypoint, enforce with lint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,7 @@
 import js from '@eslint/js';
 import tseslint from '@typescript-eslint/eslint-plugin';
 import tsparser from '@typescript-eslint/parser';
-import importPlugin from 'eslint-plugin-import-x';
+import importPlugin, { createNodeResolver } from 'eslint-plugin-import-x';
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
 
 const nodeGlobals = {
@@ -154,7 +154,46 @@ export default [
         },
       ],
     },
-  }, 
+  },
+
+  // Detect circular imports across the source tree
+  {
+    files: ['src/**/*.ts'],
+    settings: {
+      // Imports use ESM-style `.js` specifiers that point to `.ts` sources.
+      // Teach import-x to resolve (and traverse) them so `no-cycle` can build the module graph.
+      'import-x/extensions': ['.ts', '.js'],
+      'import-x/resolver-next': [
+        createNodeResolver({
+          extensions: ['.ts', '.js'],
+          extensionAlias: { '.js': ['.ts', '.js'] },
+        }),
+      ],
+    },
+    rules: {
+      'import-x/no-cycle': 'error',
+    },
+  },
+
+  // Internal modules must not depend on the public entrypoint (prevents circular imports)
+  {
+    files: ['src/lib/**/*.ts', 'src/options/**/*.ts', 'src/utils/**/*.ts'],
+    ignores: ['**/*.test.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/entrypoint.api.js', '**/backport-run.js'],
+              message:
+                'Internal modules must not import the public entrypoint — import from the canonical module (e.g. lib/backport-error.js, lib/sourceCommit/parse-source-commit.js) instead.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 
   // Test files - additional globals and relaxed rules
   {

--- a/src/backport-run.ts
+++ b/src/backport-run.ts
@@ -10,7 +10,7 @@ import { createStatusComment } from './lib/github/v3/create-status-comment.js';
 import { consoleLog, initLogger } from './lib/logger.js';
 import { ora } from './lib/ora.js';
 import { registerHandlebarsHelpers } from './lib/register-handlebars-helpers.js';
-import type { ErrorResult, Result } from './lib/run-sequentially.js';
+import type { BackportResponse, ErrorResult } from './lib/run-sequentially.js';
 import { runSequentially } from './lib/run-sequentially.js';
 import { setupRepo } from './lib/setup-repo.js';
 import type { Commit } from './lib/sourceCommit/parse-source-commit.js';
@@ -23,10 +23,7 @@ import type { ConfigFileOptions } from './options/config-options.js';
 import type { ValidConfigOptions } from './options/options.js';
 import { getActiveOptionsFormatted, getOptions } from './options/options.js';
 
-export type BackportResponse = {
-  commits: Commit[];
-  results: Result[];
-};
+export type { BackportResponse } from './lib/run-sequentially.js';
 
 export async function backportRun({
   processArgs,

--- a/src/lib/author.ts
+++ b/src/lib/author.ts
@@ -1,5 +1,5 @@
-import type { Commit } from '../entrypoint.api.js';
 import type { ValidConfigOptions } from '../options/options.js';
+import type { Commit } from './sourceCommit/parse-source-commit.js';
 
 export type CommitAuthor = { name: string; email: string };
 export function getCommitAuthor({

--- a/src/lib/cherrypickAndCreateTargetPullRequest/get-backport-branch-name.ts
+++ b/src/lib/cherrypickAndCreateTargetPullRequest/get-backport-branch-name.ts
@@ -1,7 +1,7 @@
 import Handlebars from 'handlebars';
-import type { Commit } from '../../entrypoint.api.js';
 import type { ValidConfigOptions } from '../../options/options.js';
 import { getShortSha } from '../github/commit-formatters.js';
+import type { Commit } from '../sourceCommit/parse-source-commit.js';
 
 /*
  * Returns the name of the backport branch without remote name

--- a/src/lib/cherrypickAndCreateTargetPullRequest/get-commits-without-backports.ts
+++ b/src/lib/cherrypickAndCreateTargetPullRequest/get-commits-without-backports.ts
@@ -1,9 +1,9 @@
 import chalk from 'chalk';
-import type { Commit } from '../../entrypoint.api.js';
 import type { ValidConfigOptions } from '../../options/options.js';
 import { getIsCommitInBranch } from '../git/index.js';
 import { getFirstLine } from '../github/commit-formatters.js';
 import { fetchCommitsByAuthor } from '../github/v4/fetchCommits/fetch-commits-by-author.js';
+import type { Commit } from '../sourceCommit/parse-source-commit.js';
 
 // when the user is facing a git conflict we should help them understand
 // why the conflict occurs. In many cases it's because one or more commits haven't been backported yet

--- a/src/lib/cherrypickAndCreateTargetPullRequest/get-merge-commit.ts
+++ b/src/lib/cherrypickAndCreateTargetPullRequest/get-merge-commit.ts
@@ -1,7 +1,7 @@
-import type { Commit } from '../../entrypoint.api.js';
 import type { ValidConfigOptions } from '../../options/options.js';
 import { getIsMergeCommit, getShasInMergeCommit } from '../git/index.js';
 import { fetchCommitBySha } from '../github/v4/fetchCommits/fetch-commit-by-sha.js';
+import type { Commit } from '../sourceCommit/parse-source-commit.js';
 
 export async function getMergeCommits(
   options: ValidConfigOptions,

--- a/src/lib/cherrypickAndCreateTargetPullRequest/getTargetPRLabels/get-configured-target-pr-labels.ts
+++ b/src/lib/cherrypickAndCreateTargetPullRequest/getTargetPRLabels/get-configured-target-pr-labels.ts
@@ -1,7 +1,7 @@
-import type { Commit } from '../../../entrypoint.api.js';
 import { filterNil } from '../../../utils/filter-empty.js';
 import { getSourceBranchFromCommits } from '../../get-source-branch-from-commits.js';
 import { logger } from '../../logger.js';
+import type { Commit } from '../../sourceCommit/parse-source-commit.js';
 
 // Resolve labels defined in configuration (`targetPRLabels`) into their concrete
 // values for the current target branch. This includes expanding regex captures,

--- a/src/lib/cherrypickAndCreateTargetPullRequest/getTargetPRLabels/get-target-prlabels.ts
+++ b/src/lib/cherrypickAndCreateTargetPullRequest/getTargetPRLabels/get-target-prlabels.ts
@@ -1,5 +1,5 @@
 import { uniq } from 'lodash-es';
-import type { Commit } from '../../../entrypoint.api.js';
+import type { Commit } from '../../sourceCommit/parse-source-commit.js';
 import { getConfiguredTargetPRLabels } from './get-configured-target-pr-labels.js';
 import { getSourcePRLabelsToCopy } from './get-source-pr-labels-to-copy.js';
 

--- a/src/lib/cherrypickAndCreateTargetPullRequest/list-conflicting-and-unstaged-files.ts
+++ b/src/lib/cherrypickAndCreateTargetPullRequest/list-conflicting-and-unstaged-files.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { isEmpty, difference } from 'lodash-es';
-import { BackportError } from '../../entrypoint.api.js';
 import type { ValidConfigOptions } from '../../options/options.js';
+import { BackportError } from '../backport-error.js';
 import { getConflictingFiles, getUnstagedFiles } from '../git/index.js';
 import { consoleLog } from '../logger.js';
 import { confirmPrompt } from '../prompts.js';

--- a/src/lib/cherrypickAndCreateTargetPullRequest/wait-for-cherrypick.ts
+++ b/src/lib/cherrypickAndCreateTargetPullRequest/wait-for-cherrypick.ts
@@ -1,11 +1,10 @@
 import chalk from 'chalk';
-import type { Commit } from '../../entrypoint.api.js';
-import { BackportError } from '../../entrypoint.api.js';
 import type { Ora } from '../../lib/ora.js';
 import { ora } from '../../lib/ora.js';
 import type { ValidConfigOptions } from '../../options/options.js';
 import type { CommitAuthor } from '../author.js';
 import { getCommitAuthor } from '../author.js';
+import { BackportError } from '../backport-error.js';
 import { spawnPromise } from '../child-process-promisified.js';
 import { getRepoPath } from '../env.js';
 import type { ConflictingFiles } from '../git/index.js';
@@ -17,6 +16,7 @@ import {
 } from '../git/index.js';
 import { getFirstLine } from '../github/commit-formatters.js';
 import { consoleLog, logger } from '../logger.js';
+import type { Commit } from '../sourceCommit/parse-source-commit.js';
 import { getCommitsWithoutBackports } from './get-commits-without-backports.js';
 import { listConflictingAndUnstagedFiles } from './list-conflicting-and-unstaged-files.js';
 

--- a/src/lib/get-source-branch-from-commits.ts
+++ b/src/lib/get-source-branch-from-commits.ts
@@ -1,4 +1,4 @@
-import type { Commit } from '../entrypoint.api.js';
+import type { Commit } from './sourceCommit/parse-source-commit.js';
 
 export function getSourceBranchFromCommits(commits: Commit[]) {
   // sourceBranch should be the same for all commits, so picking `sourceBranch` from the first commit should be fine 🤞

--- a/src/lib/github/v3/create-status-comment.ts
+++ b/src/lib/github/v3/create-status-comment.ts
@@ -1,7 +1,7 @@
-import type { BackportResponse } from '../../../backport-run.js';
 import type { ValidConfigOptions } from '../../../options/options.js';
 import { getPackageVersion } from '../../../utils/package-version.js';
 import { logger, redactGithubToken } from '../../logger.js';
+import type { BackportResponse } from '../../run-sequentially.js';
 import { getFirstLine } from '../commit-formatters.js';
 import { createOctokitClient, retryOctokitRequest } from './octokit-client.js';
 

--- a/src/lib/github/v4/fetchCommits/fetch-commits-for-rebase-and-merge-strategy.ts
+++ b/src/lib/github/v4/fetchCommits/fetch-commits-for-rebase-and-merge-strategy.ts
@@ -1,7 +1,7 @@
 import { first } from 'lodash-es';
-import type { Commit } from '../../../../entrypoint.api.js';
 import { graphql } from '../../../../graphql/generated/index.js';
 import { BackportError } from '../../../backport-error.js';
+import type { Commit } from '../../../sourceCommit/parse-source-commit.js';
 import { graphqlRequest } from '../client/graphql-client.js';
 import { fetchCommitBySha } from './fetch-commit-by-sha.js';
 

--- a/src/lib/run-sequentially.ts
+++ b/src/lib/run-sequentially.ts
@@ -25,6 +25,11 @@ export type ErrorResult<TCode extends BackportErrorCode = BackportErrorCode> = {
 
 export type Result = SuccessResult | ErrorResult;
 
+export type BackportResponse = {
+  commits: Commit[];
+  results: Result[];
+};
+
 export async function runSequentially({
   options,
   commits,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,7 +15,7 @@ export type {
 } from '../lib/run-sequentially.js';
 
 // Backport response type (returned by backportRun)
-export type { BackportResponse } from '../backport-run.js';
+export type { BackportResponse } from '../lib/run-sequentially.js';
 
 // Configuration types
 export type { ValidConfigOptions } from '../options/option-schema.js';

--- a/src/utils/filter-unmerged-commits.ts
+++ b/src/utils/filter-unmerged-commits.ts
@@ -1,4 +1,4 @@
-import type { Commit } from '../entrypoint.api.js';
+import type { Commit } from '../lib/sourceCommit/parse-source-commit.js';
 
 export function filterUnmergedCommits(commit: Commit) {
   return commit.targetPullRequestStates.some((pr) => pr.state !== 'MERGED');


### PR DESCRIPTION
## Problem

~11 modules under `src/lib` and `src/utils` imported `BackportError` (a value) and `Commit` (a type) from `../../entrypoint.api.js` — the public npm API — instead of the canonical modules. This created a runtime module cycle:

```
entrypoint.api -> backport-run -> run-sequentially -> cherrypick-and-create-target-pull-request -> wait-for-cherrypick -> entrypoint.api
```

which only worked thanks to ESM live bindings.

## Changes

**Import rewrites (no behavior change):**
- `Commit` (type) now imported from `src/lib/sourceCommit/parse-source-commit.ts` (its definition site) in 10 files
- `BackportError` (value) now imported from `src/lib/backport-error.ts` in 2 files
- `BackportResponse` (type) moved from `backport-run.ts` to `src/lib/run-sequentially.ts`, next to the `Result` types it composes. `backport-run.ts` re-exports it, so the public API (`entrypoint.api.ts` and the `backport` package surface) is unchanged. This was needed because `src/lib/github/v3/create-status-comment.ts` imported the type from `backport-run.ts`, which the new lint rule forbids.

**Lint enforcement (eslint.config.js):**
- `no-restricted-imports`: `src/lib/**`, `src/options/**`, `src/utils/**` (excluding tests) may not import `**/entrypoint.api.js` or `**/backport-run.js`
- `import-x/no-cycle` enabled as `error` for `src/**/*.ts` (unbounded depth — see timing below). Important detail: the codebase uses ESM-style `.js` specifiers pointing at `.ts` sources, which import-x neither resolves nor traverses by default — **no-cycle was silently a no-op without configuration**. The config now sets `import-x/extensions: ['.ts', '.js']` and a `resolver-next` node resolver with `extensionAlias: { '.js': ['.ts', '.js'] }`, verified to actually detect cycles (see below).

## Verification

- `npm run build` (codegen + tsc): passes
- `npm run lint` (tsc --noEmit + eslint): passes
- `npx vitest run --config ./vitest.config.unit.ts`: 31 files, 359 tests, all pass
- Negative test: temporarily re-introducing the `entrypoint.api.js` import in `wait-for-cherrypick.ts` makes eslint fail with both the `no-restricted-imports` message and `import-x/no-cycle` "Dependency cycle via ..." errors pinpointing the exact cycle path; reverting restores a clean lint
- `grep` confirms no non-test file under `src/lib|options|utils` imports `entrypoint.api` or `backport-run` anymore (only a doc comment mention in `src/options/option-schema.ts` remains)

## no-cycle timing

Full uncached eslint run: ~3.5s baseline vs ~4.3s with no-cycle at unbounded depth (~1.2x), so it is kept as `error` without a `maxDepth` cap. No other pre-existing cycles were found in the codebase once the entrypoint cycle was fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)