### PR TITLE
ci: build before lint/test in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
           node-version: 22.x
 
       - run: npm ci
+      # Build (GraphQL codegen + tsc) before lint/test: the prepare script no
+      # longer builds on install, and src/graphql/generated/ is gitignored, so
+      # the generated types are absent until the build runs.
+      - run: npm run build
       - run: npm audit signatures
       - run: npm run lint
       - run: npm run test:unit


### PR DESCRIPTION
## Problem

The `release` workflow has been **failing on every push to `main`** since the recent toolchain changes landed.

`release.yml` runs `npm ci` → `npm audit signatures` → `npm run lint` → `npm run test:unit` → `semantic-release`. But PR #576 changed the `prepare` script to stop building on install (build moved to `prepack`), and `src/graphql/generated/` is gitignored. So when `npm run lint` runs, the generated GraphQL types don't exist yet and `tsc` fails with dozens of:

```
error TS2307: Cannot find module '../../graphql/generated/index.js'
```

([failed run](https://github.com/sorenlouv/backport/actions/runs/27510839871))

This is a latent interaction between two PRs that were both green individually: `run-lint-and-tests.yml` already runs `npm run build` explicitly, so it passed — but `release.yml` (authored in #573 before #576 merged) never got the build step.

## Fix

Add `npm run build` after `npm ci`, matching `run-lint-and-tests.yml`.

## Verification

- YAML parses.
- The same `npm ci && npm run build && npm run lint && npm test` sequence was run locally on `main`'s state and passes (build → lint clean → 360 unit tests pass).

`ci:`-titled, so this does not itself trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)