### PR TITLE
ci: upgrade npm so release publishes via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           node-version: 22.x
 
+      # Node 22 bundles npm 10, but npm's OIDC trusted publishing requires
+      # npm >= 11.5.1. Without it, @semantic-release/npm cannot authenticate via
+      # OIDC and fails with ENONPMTOKEN. Upgrade before any npm command runs.
+      - run: npm install -g npm@latest
+
       - run: npm ci
       # Build (GraphQL codegen + tsc) before lint/test: the prepare script no
       # longer builds on install, and src/graphql/generated/ is gitignored, so


### PR DESCRIPTION
## Problem

With #582 merged, the `release` workflow now gets past build/lint/test, but the `Release` step itself fails in semantic-release's `verifyConditions`:

```
✘  ENONPMTOKEN No npm token specified.
When not publishing through trusted publishing, an npm token must be
created and set in the NPM_TOKEN environment variable...
```

([failed run](https://github.com/sorenlouv/backport/actions/runs/27511016598))

**Root cause:** the workflow deliberately uses npm [trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC, no `NPM_TOKEN`). But `actions/setup-node` with `node-version: 22.x` provides **npm 10.9.8** (verified in the run log), and npm's OIDC support requires **npm ≥ 11.5.1**. So `@semantic-release/npm` can't authenticate via OIDC and falls back to demanding a token that intentionally doesn't exist.

## Fix

Add `npm install -g npm@latest` right after `setup-node`, so every npm command — `npm ci`, `npm audit signatures`, and the semantic-release publish — runs under an npm new enough for OIDC.

## Expected result

This should turn the release job **green immediately**, publishing nothing: there are no `fix:`/`feat:` commits since `v12.0.0`, so semantic-release will report "no release" and exit 0. With npm ≥ 11.5.1 + `id-token: write`, `verifyConditions` is satisfied by OIDC and no longer requires a token.

## Still required before the first *actual* release

These don't block this PR (no publish happens yet) but are needed before the first `fix:`/`feat:` merge publishes:

1. **Push the `v12.0.1` tag** (`git push origin v12.0.1`) — npm `latest` is already `12.0.1` but the newest remote tag is `v12.0.0`, so the first release would otherwise recompute `12.0.1` and conflict.
2. **Register the npm trusted publisher** for `backport` (GitHub Actions, owner `sorenlouv`, repo `backport`, workflow `release.yml`) — the OIDC token exchange at publish time needs it.

## Minor follow-up (not in this PR)

On a *failed* release, `@semantic-release/github`'s fail step tries to open a tracking issue and gets a 422 because the default `semantic-release` label doesn't exist in this repo. It's harmless on success but masks the real error on failure. Fix by creating the label (`gh label create semantic-release`) or disabling the fail issue in `.releaserc.json`.

`ci:`-titled, so this does not itself trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)