### PR TITLE
test: verify release-label gate blocks unlabeled PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,5 @@ This tools is for anybody who is working on a codebase where they have to mainta
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/sorenlouv/backport/blob/master/CONTRIBUTING.md)
+
+<!-- release-gate verification PR; will be closed without merging -->


### PR DESCRIPTION
Throwaway PR to demonstrate the require-release-label required check blocks merge without a release:* label. Will be closed, not merged.