### PR TITLE
chore: verify release automation (e2e)

### DIFF
--- a/.github/release-automation-e2e.md
+++ b/.github/release-automation-e2e.md
@@ -1,0 +1,5 @@
+# Release automation E2E check
+
+This file exists only to trigger a patch release of `backport`, to verify that the
+downstream `backport-github-action` Dependabot + sync-version automation works.
+Safe to delete.


### PR DESCRIPTION
Dummy change to publish a patch release of `backport`, to verify end-to-end that the downstream **backport-github-action** automation works: Dependabot opens a bump PR, the new `sync-version` workflow auto-mirrors the action version, and merging releases the matching action version.

Adds one throwaway file (safe to delete after). Patch bump via the `release:patch` label.