### PR TITLE
chore: remove release-automation e2e file

### DIFF
--- a/.github/release-automation-e2e.md
+++ b/.github/release-automation-e2e.md
@@ -1,5 +1,0 @@
-# Release automation E2E check
-
-This file exists only to trigger a patch release of `backport`, to verify that the
-downstream `backport-github-action` Dependabot + sync-version automation works.
-Safe to delete.


### PR DESCRIPTION
Removes the throwaway file added in #589 to verify the backport-github-action release automation. Patch bump via `release:patch`.